### PR TITLE
Proof search for Tinue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ rand_xoshiro = "0.6.0"
 crossbeam-channel = "0.5"
 lru = "0.7.0"
 
+[profile.release]
+debug = true
+
 [dev-dependencies]
 criterion = "0.3"
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,13 +1,15 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use topaz_tak::eval::LOSE_SCORE;
+use topaz_tak::eval::{find_placement_road, LOSE_SCORE};
 use topaz_tak::search::root_minimax;
-use topaz_tak::{execute_moves_check_valid, perft, Board6, GameMove};
+use topaz_tak::{execute_moves_check_valid, perft, Bitboard6, Board6, Color, GameMove};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     // c.bench_function("small perft", |b| {
     //     b.iter(|| execute_small_perft(black_box(3)))
     // });
-    c.bench_function("small minimax", |b| b.iter(|| small_minimax(black_box(3))));
+    c.bench_function("placement road", |b| {
+        b.iter(|| placement_road(black_box(())))
+    });
 }
 
 fn execute_small_perft(depth: usize) {
@@ -32,6 +34,38 @@ fn small_minimax(depth: u16) {
     assert!(score != LOSE_SCORE);
     let only_move = GameMove::try_from_ptn("c5-", &board);
     assert_eq!(mv, only_move);
+}
+
+fn placement_road(_x: ()) {
+    // "2,x,2,2,2C,1/1,2212,1,1,x,121/12,222,1S,2S,2,x/2,x,2,x2,1/1,221,22,121,121,11C/x,2,2,2,x,1 2 32";
+    let rp = Bitboard6::new(18144415765381120);
+    let empty = Bitboard6::new(9570373622301696);
+    let color = Color::White;
+    assert_eq!(
+        find_placement_road(color, rp, empty).map(|s| s.to_ptn()),
+        Some("f4".to_string())
+    );
+    // "x,1,x4/2,2,1,1,1,1/2221,x,1,21C,x2/2,2,2C,1,2,x/2,2,1,1,1,2/2,x2,2,x,1 2 18"
+    let rp = Bitboard6::new(5143712963624960);
+    let empty = Bitboard6::new(12385175530928640);
+    let color = Color::Black;
+    assert_eq!(find_placement_road(color, rp, empty), None);
+    // "1,1,1,1,1112C,1/x,121C,x,2S,21,1/1,2,x,12221S,1S,x/x,2,2,1,x,2/x3,2S,x2/2,2,x,122121,x2 1 29"
+    let rp = Bitboard6::new(4503668386979328);
+    let empty = Bitboard6::new(29394491094466560);
+    let color = Color::White;
+    assert_eq!(find_placement_road(color, rp, empty), None);
+    // "2,x,1,x,2S,112C/2,x,1,121,x2/x2,1S,x,22221,x/x2,1,x,112222221C,x/x,112S,12,221S,21,21/1,1,x,2,x,1 1 44"
+    let rp = Bitboard6::new(19808973823150080);
+    let empty = Bitboard6::new(11261568908268544);
+    let color = Color::White;
+    assert!(find_placement_road(color, rp, empty).is_some());
+    // "2,x4,1/x4,1,x/x,2,12C,1,1,x/x,1,2,21C,x2/x,2,2,x3/x2,2,1,x2 1 10"
+    let rp = Bitboard6::new(4503686334136320);
+    let empty = Bitboard6::new(28836213970320384);
+    let color = Color::White;
+
+    assert_eq!(find_placement_road(color, rp, empty), None);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/src/board.rs
+++ b/src/board.rs
@@ -198,6 +198,13 @@ impl Board6 {
         let updated = road_pieces ^ (road_pieces ^ update) & mask;
         updated.check_road()
     }
+    pub fn make_ptn_moves(&mut self, moves: &[&str]) -> Option<()> {
+        for s in moves {
+            let m = GameMove::try_from_ptn(s, self)?;
+            self.do_move(m);
+        }
+        Some(())
+    }
 }
 
 fn parse_tps_stack(tile: &str) -> Result<Vec<Piece>> {

--- a/src/board/bitboard.rs
+++ b/src/board/bitboard.rs
@@ -115,6 +115,7 @@ pub trait Bitboard:
     + std::ops::Sub<Output = Self>
     + std::ops::SubAssign
     + std::ops::Not<Output = Self>
+    + std::ops::BitXor<Output = Self>
 {
     const ZERO: Self;
     fn adjacent(self) -> Self;
@@ -183,6 +184,13 @@ impl std::ops::Sub for Bitboard6 {
 impl std::ops::SubAssign for Bitboard6 {
     fn sub_assign(&mut self, rhs: Self) {
         self.0 -= rhs.0;
+    }
+}
+
+impl std::ops::BitXor for Bitboard6 {
+    type Output = Self;
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        Self(self.0 ^ rhs.0)
     }
 }
 

--- a/src/board/bitboard.rs
+++ b/src/board/bitboard.rs
@@ -1,4 +1,4 @@
-use super::{Board6, Piece, Stack};
+use super::{Piece, Stack};
 use crate::board::zobrist::TABLE;
 use board_game_traits::Color;
 
@@ -367,7 +367,7 @@ mod test {
         use board_game_traits::Position;
         let tps =
             "2,x4,1/2,2,x2,1,x/2,212C,x,1,1,x/2,1,x,2S,12S,x/12,12221C,x,12,1,1/1S,12,x,1,1,x 1 22";
-        let board = Board6::try_from_tps(tps).unwrap();
+        let board = crate::Board6::try_from_tps(tps).unwrap();
         let bitboards = BitboardStorage::<Bitboard6>::build_6(&board.board);
         let stacks1: Vec<_> = bitboards.iter_stacks(board.side_to_move()).collect();
         let stacks2 = board.scan_active_stacks(board.side_to_move());

--- a/src/board/piece.rs
+++ b/src/board/piece.rs
@@ -88,6 +88,19 @@ impl Piece {
             Piece::BlackWall => Piece::WhiteWall,
         }
     }
+    pub fn road_piece(self, color: Color) -> bool {
+        if let Color::White = color {
+            match self {
+                Piece::WhiteFlat | Piece::WhiteCap => true,
+                _ => false,
+            }
+        } else {
+            match self {
+                Piece::BlackFlat | Piece::BlackCap => true,
+                _ => false,
+            }
+        }
+    }
 }
 
 impl std::fmt::Debug for Piece {

--- a/src/board/stack.rs
+++ b/src/board/stack.rs
@@ -1,5 +1,4 @@
 use super::bitboard::{Bitboard, BitboardStorage};
-use super::zobrist::TABLE;
 use super::Piece;
 
 #[derive(PartialEq, Clone, Debug)]

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -157,23 +157,29 @@ impl Evaluate for Board6 {
         if let Some(suggestions) = hint {
             for m in suggestions.iter().copied() {
                 if storage.contains(&m) {
-                    let rev = self.do_move(m);
-                    let road = self.road(player);
-                    self.reverse_move(rev);
-                    if road {
+                    if self.road_stack_throw(road_pieces, m) {
                         return Some(m);
                     }
+                    // let rev = self.do_move(m);
+                    // let road = self.road(player);
+                    // self.reverse_move(rev);
+                    // if road {
+                    //     return Some(m);
+                    // }
                 }
             }
         }
         // Todo optimize this
         for m in storage.iter().copied() {
-            let rev = self.do_move(m);
-            let road = self.road(player);
-            self.reverse_move(rev);
-            if road {
+            if self.road_stack_throw(road_pieces, m) {
                 return Some(m);
             }
+            // let rev = self.do_move(m);
+            // let road = self.road(player);
+            // self.reverse_move(rev);
+            // if road {
+            //     return Some(m);
+            // }
         }
         // for m in stack_moves {
         //     let mut bits = Bitboard6::ZERO;

--- a/src/move_gen.rs
+++ b/src/move_gen.rs
@@ -1,5 +1,4 @@
 use super::{Board6, Piece};
-use anyhow::{bail, ensure, Result};
 use board_game_traits::{Color, Position};
 use std::fmt;
 

--- a/src/move_gen.rs
+++ b/src/move_gen.rs
@@ -153,7 +153,7 @@ impl GameMove {
     pub fn is_place_move(self) -> bool {
         (self.0 & Self::PLACEMENT_BITS) > 0
     }
-    fn slide_bits(self) -> u64 {
+    pub fn slide_bits(self) -> u64 {
         let bits = self.0 & 0xFFFFFFF000;
         bits >> 12
     }
@@ -166,7 +166,7 @@ impl GameMove {
     pub fn src_index(self) -> usize {
         self.0 as usize & 0x3F
     }
-    fn direction(self) -> u64 {
+    pub fn direction(self) -> u64 {
         (self.0 & 0xC0) >> 6
     }
     fn set_index(self, index: u64) -> Self {

--- a/src/move_gen.rs
+++ b/src/move_gen.rs
@@ -42,6 +42,24 @@ pub fn generate_all_place_moves(board: &Board6, moves: &mut Vec<GameMove>) {
     }
 }
 
+/// Generates all cap or flat placement moves. Used for Tinue checking
+pub fn generate_aggressive_place_moves(board: &Board6, moves: &mut Vec<GameMove>) {
+    let side_to_move = board.side_to_move();
+    let start_locs = board.empty_tiles();
+    let (flat, cap) = match side_to_move {
+        Color::White => (Piece::WhiteFlat, Piece::WhiteCap),
+        Color::Black => (Piece::BlackFlat, Piece::BlackCap),
+    };
+    if board.caps_reserve(side_to_move) > 0 {
+        for index in start_locs {
+            moves.push(GameMove::from_placement(cap, index));
+        }
+    }
+    for index in board.empty_tiles() {
+        moves.push(GameMove::from_placement(flat, index));
+    }
+}
+
 /// Generates all legal sliding movements for the active player's stacks.
 pub fn generate_all_stack_moves(board: &Board6, moves: &mut Vec<GameMove>) {
     let start_locs = board.active_stacks(board.side_to_move());

--- a/src/search.rs
+++ b/src/search.rs
@@ -7,7 +7,7 @@ use crossbeam_channel::Receiver;
 use lru::LruCache;
 use std::time::Instant;
 
-mod proof;
+pub mod proof;
 
 const NULL_REDUCTION: usize = 2;
 
@@ -338,7 +338,7 @@ where
     }
     // Do a slower, more thorough move ordering at the root
     if info.ply_depth(board) == 0 {
-        let tak_threats = board.get_tak_threats(&moves);
+        let tak_threats = board.get_tak_threats(&moves, None);
         for m in moves.iter_mut() {
             if tak_threats.contains(m) {
                 m.add_score(50);

--- a/src/search.rs
+++ b/src/search.rs
@@ -7,6 +7,8 @@ use crossbeam_channel::Receiver;
 use lru::LruCache;
 use std::time::Instant;
 
+mod proof;
+
 const NULL_REDUCTION: usize = 2;
 
 pub struct SearchInfo {

--- a/src/search/proof.rs
+++ b/src/search/proof.rs
@@ -1,0 +1,258 @@
+use super::*;
+use crate::eval::Evaluate;
+use crate::generate_all_moves;
+use crate::{Board6, Position, RevGameMove};
+use std::cmp::{max, min};
+use std::collections::HashMap;
+
+const INFINITY: u32 = 1_000_000;
+
+#[derive(Clone)]
+pub struct Child {
+    bounds: Bounds,
+    game_move: GameMove,
+    zobrist: u64,
+    best_child: usize,
+}
+
+impl Child {
+    pub fn new(bounds: Bounds, game_move: GameMove, zobrist: u64) -> Self {
+        Self {
+            bounds,
+            game_move,
+            zobrist,
+            best_child: usize::MAX,
+        }
+    }
+    pub fn update_bounds(&mut self, bounds: Bounds, table: &mut HashMap<u64, Bounds>) {
+        self.bounds = bounds;
+        table.insert(self.zobrist, bounds);
+    }
+    pub fn phi(&self) -> u32 {
+        self.bounds.phi
+    }
+    pub fn delta(&self) -> u32 {
+        self.bounds.delta
+    }
+}
+
+pub fn compute_bounds(children: &[Child]) -> Bounds {
+    let mut out = Bounds {
+        phi: INFINITY,
+        delta: 0,
+    };
+    for ch in children.iter() {
+        out.phi = min(out.phi, ch.bounds.delta);
+        out.delta = out.delta.saturating_add(ch.bounds.phi);
+    }
+    out.delta = min(out.delta, INFINITY);
+    return out;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Bounds {
+    phi: u32,
+    delta: u32,
+}
+
+impl Bounds {
+    pub fn winning() -> Self {
+        Bounds {
+            phi: 0,
+            delta: INFINITY,
+        }
+    }
+
+    pub fn losing() -> Self {
+        Bounds {
+            phi: INFINITY,
+            delta: 0,
+        }
+    }
+
+    pub fn unity() -> Self {
+        Bounds { phi: 1, delta: 1 }
+    }
+
+    pub fn infinity() -> Self {
+        Bounds {
+            phi: INFINITY,
+            delta: INFINITY,
+        }
+    }
+
+    pub fn root() -> Self {
+        Bounds {
+            phi: INFINITY / 2,
+            delta: INFINITY / 2,
+        }
+    }
+}
+
+impl Default for Bounds {
+    fn default() -> Self {
+        Self::unity()
+    }
+}
+
+struct TinueSearch {
+    board: Board6,
+    bounds_table: HashMap<u64, Bounds>,
+    rev_moves: Vec<RevGameMove>,
+    attacker: Color,
+    nodes: usize,
+}
+
+impl TinueSearch {
+    fn is_tinue(board: Board6) -> bool {
+        let attacker = board.side_to_move();
+        let mut search = Self {
+            board,
+            bounds_table: HashMap::new(),
+            rev_moves: Vec::new(),
+            attacker,
+            nodes: 0,
+        };
+        let mut root = Child::new(Bounds::root(), GameMove::null_move(), search.board.hash());
+        search.MID(&mut root, 0);
+        dbg!(search.nodes);
+        if root.delta() == INFINITY {
+            true
+        } else {
+            false
+        }
+    }
+    fn MID(&mut self, child: &mut Child, depth: usize) {
+        self.nodes += 1;
+        if child.game_move != GameMove::null_move() {
+            let rev = self.board.do_move(child.game_move);
+            self.rev_moves.push(rev);
+        }
+        assert_eq!(child.zobrist, self.board.hash());
+        let side_to_move = self.board.side_to_move();
+        let attacker = side_to_move == self.attacker;
+        let moves = if attacker {
+            match tinue_evaluate(&mut self.board) {
+                AttackerOutcome::HasRoad(_m) => {
+                    let eval = Bounds::winning();
+                    child.update_bounds(eval, &mut self.bounds_table);
+                    self.undo_move();
+                    return;
+                }
+                AttackerOutcome::TakThreats(vec) => vec,
+                AttackerOutcome::NoTakThreats => {
+                    let eval = Bounds::losing();
+                    child.update_bounds(eval, &mut self.bounds_table);
+                    self.undo_move();
+                    return;
+                }
+            }
+        } else {
+            let mut moves = Vec::new();
+            generate_all_moves(&mut self.board, &mut moves);
+            moves
+                .into_iter()
+                .filter(|m| !m.is_place_move() || m.place_piece().is_blocker())
+                .collect()
+        };
+        assert!(!moves.is_empty());
+
+        if child.game_move == GameMove::null_move() {
+            let debug_vec: Vec<_> = moves.iter().map(|m| m.to_ptn()).collect();
+            dbg!(&debug_vec); // Root moves?
+        }
+        // generate_all_moves(&mut self.board, &mut moves);
+        let mut child_pns: Vec<_> = moves.into_iter().map(|m| self.init_pns(m)).collect();
+        loop {
+            let limit = compute_bounds(&child_pns);
+            if child.phi() <= limit.phi || child.delta() <= limit.delta {
+                child.update_bounds(limit, &mut self.bounds_table);
+                self.undo_move();
+                return;
+            }
+            let (best_idx, second_best_bounds) = Self::select_child(&child_pns);
+            let best_child = &mut child_pns[best_idx];
+            // println!("Depth: {} Move: {}", depth, best_child.game_move.to_ptn());
+            let updated_bounds = Bounds {
+                phi: child.delta() + best_child.phi() - limit.delta,
+                delta: min(child.phi(), second_best_bounds.delta + 1),
+            };
+            best_child.update_bounds(updated_bounds, &mut self.bounds_table);
+            self.MID(best_child, depth + 1);
+        }
+    }
+    fn select_child(children: &[Child]) -> (usize, Bounds) {
+        let mut c_best_idx = 0;
+        let mut best = children[c_best_idx].bounds;
+        let mut second_best = Bounds::infinity();
+        for (idx, child) in children.iter().enumerate().skip(1) {
+            if child.bounds.delta < best.delta {
+                c_best_idx = idx;
+                second_best = best;
+                best = child.bounds;
+            } else if child.bounds.delta < second_best.delta {
+                second_best = child.bounds;
+            }
+            if child.bounds.phi == INFINITY {
+                return (c_best_idx, second_best);
+            }
+        }
+        (c_best_idx, second_best)
+    }
+    fn init_pns(&mut self, game_move: GameMove) -> Child {
+        let rev = self.board.do_move(game_move);
+        let hash = self.board.hash();
+        let bounds = self.bounds_table.entry(hash).or_default();
+        let child = Child::new(bounds.clone(), game_move, hash);
+        self.board.reverse_move(rev);
+        child
+    }
+    fn undo_move(&mut self) -> Option<()> {
+        let m = self.rev_moves.pop()?;
+        self.board.reverse_move(m);
+        Some(())
+    }
+}
+
+enum AttackerOutcome {
+    HasRoad(GameMove),
+    TakThreats(Vec<GameMove>),
+    NoTakThreats,
+}
+
+fn tinue_evaluate(pos: &mut Board6) -> AttackerOutcome {
+    let mut moves = Vec::new();
+    if let Some(m) = pos.can_make_road(&mut moves) {
+        return AttackerOutcome::HasRoad(m);
+    }
+    // Moves contains all stack moves due to the can_make_road call
+    crate::move_gen::generate_aggressive_place_moves(pos, &mut moves);
+    let tak_threats = pos.get_tak_threats(&moves);
+    if tak_threats.is_empty() {
+        AttackerOutcome::NoTakThreats
+    } else {
+        AttackerOutcome::TakThreats(tak_threats)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn simple() {
+        let s = "x2,2,x2,1/x5,1/x,2,x,1,1,1/x,2,x2,1,x/x,2C,x4/x,2,x4 2 6";
+        let board = Board6::try_from_tps(s).unwrap();
+        dbg!(&board);
+        assert!(TinueSearch::is_tinue(board));
+    }
+    #[test]
+    fn simple2() {
+        let s = "1,1,1,1,1112C,1/x,121C,x,1,2,1/1,2,x,12,1S,x/x,2,2,1221S,x,2/x3,121,x2/2,2,2,1,2,x 1 25";
+        let s2 =
+            "1,1,1,1,1112C,1/x,x,x,1,2,1/1,2,x,12,1S,x/x,2,2,1221S,x,2/x3,121,x2/2,2,2,1,2,x 1 25";
+        let board = Board6::try_from_tps(s).unwrap();
+        assert!(TinueSearch::is_tinue(board));
+
+        assert!(!TinueSearch::is_tinue(Board6::try_from_tps(s2).unwrap()));
+    }
+}

--- a/src/search/proof.rs
+++ b/src/search/proof.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::eval::Evaluate;
 use crate::generate_all_moves;
 use crate::{Board6, Position, RevGameMove};
-use std::cmp::{max, min};
+use std::cmp::min;
 use std::collections::HashMap;
 
 const INFINITY: u32 = 100_000_000;
@@ -78,11 +78,6 @@ impl Bounds {
             delta: 0,
         }
     }
-
-    pub fn unity() -> Self {
-        Bounds { phi: 1, delta: 1 }
-    }
-
     pub fn infinity() -> Self {
         Bounds {
             phi: INFINITY,
@@ -105,11 +100,6 @@ impl Default for Bounds {
             delta: 100,
         }
     }
-}
-
-enum ProofNode {
-    Attack(GameMove, Box<ProofNode>),
-    Defense(Vec<GameMove>, Vec<ProofNode>),
 }
 
 #[derive(Clone)]
@@ -174,7 +164,7 @@ impl TinueSearch {
     }
     pub fn is_tinue(&mut self) -> bool {
         let mut root = Child::new(Bounds::root(), GameMove::null_move(), self.board.hash());
-        self.MID(&mut root, 0);
+        self.mid(&mut root, 0);
         dbg!(self.nodes);
         dbg!(self.tinue_cache_hits);
         dbg!(self.tinue_cache_misses);
@@ -216,10 +206,7 @@ impl TinueSearch {
         }
         pv
     }
-    fn proof_tree(&mut self) -> ProofNode {
-        todo!();
-    }
-    fn MID(&mut self, child: &mut Child, depth: usize) {
+    fn mid(&mut self, child: &mut Child, depth: usize) {
         self.nodes += 1;
         if child.game_move != GameMove::null_move() {
             let rev = self.board.do_move(child.game_move);
@@ -307,7 +294,7 @@ impl TinueSearch {
                 delta: min(child.phi(), second_best_bounds.delta + 1),
             };
             best_child.update_bounds(updated_bounds, &mut self.bounds_table);
-            self.MID(best_child, depth + 1);
+            self.mid(best_child, depth + 1);
         }
     }
     fn select_child(children: &[Child]) -> (usize, Bounds) {

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -31,7 +31,9 @@ pub fn main() {
             let alion3 = "x2,1,21,2,2/1,2,21,1,21,2/1S,2,2,2C,2,2/21S,1,121C,x,1,12/2,2,121,1,1,1/2,2,x3,22S 1 27";
             let alion2 = "2,212221C,2,2,2C,1/1,2,1,1,2,1/12,x,1S,2S,2,1/2,2,2,x2,1/1,2212121S,2,12,1,1S/x,2,2,2,x,1 1 30";
             let alion1 = "2,1221122,1,1,1,2S/1,1,1,x,1C,1111212/x2,2,212,2C,11/2,2,x2,1,1/x3,1,1,x/x2,2,21,x,112S 2 32";
-            let mut board = Board6::try_from_tps(alion2).unwrap();
+            // Alion Benchmarks: 2s, 7m, 18m, 2s, X
+            // Alion Benchmarks: 0s, 5s, 16s, 0s, X
+            let board = Board6::try_from_tps(alion2).unwrap();
             let mut search = crate::search::proof::TinueSearch::new(board);
 
             // let subpos =

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -53,8 +53,7 @@ pub fn main() {
             }
 
             // Todo Allow checking refuted sidelines from command line
-
-            // let side_line = vec!["2f5-".to_string(), "f3+".to_string()];
+            // let side_line = side_line.into_iter().map(|s| s.to_string()).collect();
             // let side = search.side_variation(side_line);
             // println!("Side Variation: ");
             // for m in side.into_iter().map(|m| m.to_ptn()) {

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -12,48 +12,47 @@ use topaz_tak::*;
 pub fn main() {
     let args: Vec<String> = env::args().collect();
 
-    if let Some(color_str) = args.get(1) {
-        if color_str == "black" {
+    if let Some(arg1) = args.get(1) {
+        if arg1 == "black" {
             play_game_cmd(false);
-        } else if color_str == "white" {
+        } else if arg1 == "white" {
             play_game_cmd(true);
-        } else if color_str == "tinue" {
+        } else if arg1 == "tinue" {
+            let mut rest = String::new();
+            for s in args[2..].iter() {
+                rest.push_str(s);
+                rest.push_str(" ");
+            }
+            rest.pop();
+            let tps = match rest.as_str() {
+                "alion1" => "2,1221122,1,1,1,2S/1,1,1,x,1C,1111212/x2,2,212,2C,11/2,2,x2,1,1/x3,1,1,x/x2,2,21,x,112S 2 32",
+                "alion2" => "2,212221C,2,2,2C,1/1,2,1,1,2,1/12,x,1S,2S,2,1/2,2,2,x2,1/1,2212121S,2,12,1,1S/x,2,2,2,x,1 1 30",
+                "alion3" => "x2,1,21,2,2/1,2,21,1,21,2/1S,2,2,2C,2,2/21S,1,121C,x,1,12/2,2,121,1,1,1/2,2,x3,22S 1 27",
+                "alion4" => "x,1,x4/2,2,1,1,1,1/2221,x,1,21C,x2/2,2,2C,1,2,x/2,2,1,1,1,2/2,x2,2,x,1 2 18",
+                "alion5" => "2,x4,11/x5,221/x,2,2,2,x,221/2,1,12C,1,21C,2/2,x,2,x2,2/x,2,2,2,x,121 1 25",
+                _ => rest.as_str(),
+            };
             let time = Instant::now();
-            // let s = "2,x4,11/x5,221/x,2,2,2,x,221/2,1,12C,1,21C,2/2,x,2,x2,2/x,2,2,2,x,121 1 25";
-            // let s = "1,1,1,1,1112C,1/x,121C,x,1,2,1/1,2,x,12,1S,x/x,2,2,1221S,x,2/x3,121,x2/2,2,2,1,2,x 1 25";
-            // let s = "1221,1,1,x2,1/x3,111,x,2221C/2,2,12,111112C,11,1/2,x,1,1,112S,x/2,x,1,2,x2/2,x,2,1,x2 1 31";
-            // Alion's 5th puzzle contains a cycle
-            let alion5 =
-                "2,x4,11/x5,221/x,2,2,2,x,221/2,1,12C,1,21C,2/2,x,2,x2,2/x,2,2,2,x,121 1 25";
-            let alion4 =
-                "x,1,x4/2,2,1,1,1,1/2221,x,1,21C,x2/2,2,2C,1,2,x/2,2,1,1,1,2/2,x2,2,x,1 2 18";
-            // let morten = "x6/x,1,x,1,x2/21,x5/2,x2,1C,2,x/2,2212,21,21,2,x/x,221112C,x3,1 2 18"; // Type 2
-            let alion3 = "x2,1,21,2,2/1,2,21,1,21,2/1S,2,2,2C,2,2/21S,1,121C,x,1,12/2,2,121,1,1,1/2,2,x3,22S 1 27";
-            let alion2 = "2,212221C,2,2,2C,1/1,2,1,1,2,1/12,x,1S,2S,2,1/2,2,2,x2,1/1,2212121S,2,12,1,1S/x,2,2,2,x,1 1 30";
-            let alion1 = "2,1221122,1,1,1,2S/1,1,1,x,1C,1111212/x2,2,212,2C,11/2,2,x2,1,1/x3,1,1,x/x2,2,21,x,112S 2 32";
-            // Alion Benchmarks: 2s, 7m, 18m, 2s, X
-            // Alion Benchmarks: 0s, 5s, 16s, 0s, X
-            let board = Board6::try_from_tps(alion2).unwrap();
+            let board = match Board6::try_from_tps(tps) {
+                Ok(b) => b,
+                Err(_) => {
+                    println!("Unable to create game with tps: \n{}", tps);
+                    return;
+                }
+            };
             let mut search = crate::search::proof::TinueSearch::new(board);
-
-            // let subpos =
-            //     "2,x4,11/x5,221/x,2,2,2,x,2/2,1,12C,1,x,22121C/2,x,2,x2,221/x,2,2,2,x,1 2 36";
             let tinue = search.is_tinue();
-            // let board2 = Board6::try_from_tps(alion5).unwrap();
-            // assert_eq!(board2.hash(), search.board.hash());
-            // let board6 = Board6::try_from_tps(subpos).unwrap();
-            // assert!(search.replies.get(&board6.hash()).is_some());
-            // let side_line = vec!["2e3>".to_string(), "f2-".to_string()];
-            // let side = search.side_variation(side_line);
-            // println!("Side Variation: ");
-            // for m in side.into_iter().map(|m| m.to_ptn()) {
-            //     println!("{}", m);
-            // }
-            assert!(tinue);
+            if tinue {
+                println!("Tinue Found!")
+            } else {
+                println!("No Tinue Found.");
+            }
             let pv = search.principal_variation();
             for m in pv.into_iter().map(|m| m.to_ptn()) {
                 println!("{}", m);
             }
+
+            // Todo Allow checking refuted sidelines from command line
 
             // let side_line = vec!["2f5-".to_string(), "f3+".to_string()];
             // let side = search.side_variation(side_line);
@@ -61,15 +60,11 @@ pub fn main() {
             // for m in side.into_iter().map(|m| m.to_ptn()) {
             //     println!("{}", m);
             // }
-            // let mut info = SearchInfo::new(10, 300000);
-            // search(&mut board, &mut info);
-            // let pv_move = info.pv_move(&board).unwrap();
-            // println!("{}", pv_move.to_ptn());
             let seconds = time.elapsed().as_secs();
             println!("Done in {} seconds", seconds);
             return;
         } else {
-            println!("Unknown argument: {}", color_str);
+            println!("Unknown argument: {}", arg1);
         }
     }
     let mut buffer = String::new();
@@ -80,7 +75,7 @@ pub fn main() {
         let (s, r) = unbounded();
         tei_loop(s);
         identify();
-        play_game_tei(r);
+        let _ = play_game_tei(r);
     } else if buffer == "play white" {
         play_game_cmd(true)
     } else if buffer == "play black" {

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -4,7 +4,7 @@ use crossbeam_channel::{unbounded, Receiver, Sender};
 use std::env;
 use std::io::{self, BufRead};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use topaz_tak::eval::Evaluate;
 use topaz_tak::search::{search, SearchInfo};
 use topaz_tak::*;

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -4,6 +4,7 @@ use crossbeam_channel::{unbounded, Receiver, Sender};
 use std::env;
 use std::io::{self, BufRead};
 use std::thread;
+use std::time::{Duration, Instant};
 use topaz_tak::eval::Evaluate;
 use topaz_tak::search::{search, SearchInfo};
 use topaz_tak::*;
@@ -16,6 +17,55 @@ pub fn main() {
             play_game_cmd(false);
         } else if color_str == "white" {
             play_game_cmd(true);
+        } else if color_str == "tinue" {
+            let time = Instant::now();
+            // let s = "2,x4,11/x5,221/x,2,2,2,x,221/2,1,12C,1,21C,2/2,x,2,x2,2/x,2,2,2,x,121 1 25";
+            // let s = "1,1,1,1,1112C,1/x,121C,x,1,2,1/1,2,x,12,1S,x/x,2,2,1221S,x,2/x3,121,x2/2,2,2,1,2,x 1 25";
+            // let s = "1221,1,1,x2,1/x3,111,x,2221C/2,2,12,111112C,11,1/2,x,1,1,112S,x/2,x,1,2,x2/2,x,2,1,x2 1 31";
+            // Alion's 5th puzzle contains a cycle
+            let alion5 =
+                "2,x4,11/x5,221/x,2,2,2,x,221/2,1,12C,1,21C,2/2,x,2,x2,2/x,2,2,2,x,121 1 25";
+            let alion4 =
+                "x,1,x4/2,2,1,1,1,1/2221,x,1,21C,x2/2,2,2C,1,2,x/2,2,1,1,1,2/2,x2,2,x,1 2 18";
+            // let morten = "x6/x,1,x,1,x2/21,x5/2,x2,1C,2,x/2,2212,21,21,2,x/x,221112C,x3,1 2 18"; // Type 2
+            let alion3 = "x2,1,21,2,2/1,2,21,1,21,2/1S,2,2,2C,2,2/21S,1,121C,x,1,12/2,2,121,1,1,1/2,2,x3,22S 1 27";
+            let alion2 = "2,212221C,2,2,2C,1/1,2,1,1,2,1/12,x,1S,2S,2,1/2,2,2,x2,1/1,2212121S,2,12,1,1S/x,2,2,2,x,1 1 30";
+            let alion1 = "2,1221122,1,1,1,2S/1,1,1,x,1C,1111212/x2,2,212,2C,11/2,2,x2,1,1/x3,1,1,x/x2,2,21,x,112S 2 32";
+            let mut board = Board6::try_from_tps(alion2).unwrap();
+            let mut search = crate::search::proof::TinueSearch::new(board);
+
+            // let subpos =
+            //     "2,x4,11/x5,221/x,2,2,2,x,2/2,1,12C,1,x,22121C/2,x,2,x2,221/x,2,2,2,x,1 2 36";
+            let tinue = search.is_tinue();
+            // let board2 = Board6::try_from_tps(alion5).unwrap();
+            // assert_eq!(board2.hash(), search.board.hash());
+            // let board6 = Board6::try_from_tps(subpos).unwrap();
+            // assert!(search.replies.get(&board6.hash()).is_some());
+            // let side_line = vec!["2e3>".to_string(), "f2-".to_string()];
+            // let side = search.side_variation(side_line);
+            // println!("Side Variation: ");
+            // for m in side.into_iter().map(|m| m.to_ptn()) {
+            //     println!("{}", m);
+            // }
+            assert!(tinue);
+            let pv = search.principal_variation();
+            for m in pv.into_iter().map(|m| m.to_ptn()) {
+                println!("{}", m);
+            }
+
+            // let side_line = vec!["2f5-".to_string(), "f3+".to_string()];
+            // let side = search.side_variation(side_line);
+            // println!("Side Variation: ");
+            // for m in side.into_iter().map(|m| m.to_ptn()) {
+            //     println!("{}", m);
+            // }
+            // let mut info = SearchInfo::new(10, 300000);
+            // search(&mut board, &mut info);
+            // let pv_move = info.pv_move(&board).unwrap();
+            // println!("{}", pv_move.to_ptn());
+            let seconds = time.elapsed().as_secs();
+            println!("Done in {} seconds", seconds);
+            return;
         } else {
             println!("Unknown argument: {}", color_str);
         }


### PR DESCRIPTION
Use the proof number search to see if it's possible to "brute force" a Tinue by repeatedly making Tak threats. This is useful in its own right for verifying the solutions of Tinue Puzzles. Although "repeatedly make tak threats until you win" is the most obvious heuristic for solving these puzzles, even finding all Tak threats in a position naively is equivalent to a 3 ply search, which is tricky for humans. Thus, a large number of Tinue puzzles are solvable using this search. 

For the main engine, this was mainly useful because it forced me to optimize the routines that generate Tak threat moves, which ideally would be moves that are weighted very highly by move ordering. Additionally, this may make it more reasonable to perform a quiescence search that deepens until a Player is no longer in Tak (this was computationally infeasible before). A more exotic decision may be to run the proof search in parallel to the main search on a separate thread.   