### PR TITLE
Better eval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+*.csv
+*.svg
+perf.*

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -6,14 +6,14 @@ use topaz_tak::search::root_minimax;
 use topaz_tak::{execute_moves_check_valid, perft, Color, GameMove};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    // c.bench_function("small perft", |b| {
-    //     b.iter(|| execute_small_perft(black_box(3)))
-    // });
-    let pos = get_positions();
-    let eval = Evaluator6 {};
-    c.bench_function("eval", |b| {
-        b.iter(|| evaluate_positions(black_box(&pos), black_box(&eval)))
+    c.bench_function("small perft", |b| {
+        b.iter(|| execute_small_perft(black_box(2)))
     });
+    // let pos = get_positions();
+    // let eval = Evaluator6 {};
+    // c.bench_function("eval", |b| {
+    //     b.iter(|| evaluate_positions(black_box(&pos), black_box(&eval)))
+    // });
 }
 
 fn execute_small_perft(depth: usize) {

--- a/src/board/bitboard.rs
+++ b/src/board/bitboard.rs
@@ -63,6 +63,13 @@ where
         };
         road_pieces
     }
+    pub fn blocker_pieces(&self, color: Color) -> T {
+        let blocker_pieces = match color {
+            Color::White => (self.wall | self.cap) & self.white,
+            Color::Black => (self.wall | self.cap) & self.black,
+        };
+        blocker_pieces
+    }
     pub fn check_road(&self, color: Color) -> bool {
         self.road_pieces(color).check_road()
     }
@@ -121,16 +128,48 @@ pub trait Bitboard:
     + std::ops::BitXor<Output = Self>
 {
     const ZERO: Self;
+    /// Returns all bits adjacent to a bitboard by sliding the entire bitboard in
+    /// all 4 directions. 
+    /// 
+    /// Note: when only a single bit is included, the adjacent bits will not include
+    /// the provided bit itself. However, because of the interactions between multiple bits, 
+    /// many of the initial values may remain set depending on the input bit configuration. 
     fn adjacent(self) -> Self;
+    /// Flood fills and sets bits where the left + right or top + bottom edges 
+    /// are one square away from meeting. 
+    /// 
+    /// In other words, when set with the appropriate bits, this can detect which
+    /// squares would win the game for a player if filled in with a flat placement.
+    /// This is used to quickly detect a subset of positions where a player is in Tak. 
+    /// If complete tak threat detection is necessary, there must be a slower method 
+    /// to fall back on which detects stack movement roads. 
+    /// 
+    /// The bits returned are not interpretable if a position is passed in where
+    /// two edges of the board already meet. As such, it is not reasonable to use
+    /// all white pieces as the input: walls should be excluded. However, more 
+    /// creative uses of this function could be attempted to get a cheap, rough assessment
+    /// of the danger of a position. 
     fn critical_squares(self) -> Self;
+    /// Performs a flood fill to reveal all bits connected to a provided edge 
     fn flood(self, edge: Self) -> Self;
+    /// Returns true if two opposite edges are connected by the provided bits
     fn check_road(self) -> bool;
+    /// Pops the lowest bit index in the bitboard.
+    /// 
+    /// This unsets the bit in the bitboard and returns a new bitboard where only
+    /// that single bit is set. 
     fn pop_lowest(&mut self) -> Self;
+    /// Returns true if any of the bits in the bitboard are set.
     fn nonzero(&self) -> bool;
+    /// Returns the number of ones set in the bitboard
     fn pop_count(self) -> u32;
+    /// Returns true if all the bits in the bitboard's intended range are set
     fn all_ones(self) -> bool;
+    /// Finds the lowest set index in the bitboard and returns it as a [TakBoard] square index
     fn lowest_index(self) -> usize;
+    /// Converts a provided [TakBoard] square index into a single set bit in a bitboard
     fn index_to_bit(index: usize) -> Self;
+    /// Returns the board size that this bitboard corresponds to
     fn size() -> usize;
 }
 

--- a/src/board/bitboard.rs
+++ b/src/board/bitboard.rs
@@ -154,6 +154,8 @@ pub trait Bitboard:
     fn flood(self, edge: Self) -> Self;
     /// Returns true if two opposite edges are connected by the provided bits
     fn check_road(self) -> bool;
+    /// Returns the lowest bit index in the bitboard without modifying self
+    fn lowest(&self) -> Self;
     /// Pops the lowest bit index in the bitboard.
     /// 
     /// This unsets the bit in the bitboard and returns a new bitboard where only
@@ -418,6 +420,15 @@ macro_rules! bitboard_impl {
                     unchecked = unchecked & !component;
                 }
                 false
+            }
+            fn lowest(&self) -> Self {
+                let highest_index = self.0.trailing_zeros();
+                if highest_index == 64 {
+                    Self::new(0)
+                } else {
+                    let value = 1 << highest_index;
+                    Self::new(value)
+                }
             }
             fn pop_lowest(&mut self) -> Self {
                 let highest_index = self.0.trailing_zeros();

--- a/src/board/bitboard.rs
+++ b/src/board/bitboard.rs
@@ -423,6 +423,10 @@ pub struct BitIndexIterator<T> {
     bits: T,
 }
 
+impl<T> BitIndexIterator<T> {
+    pub fn new(bits: T) -> Self { Self { bits } }
+}
+
 impl<T> Iterator for BitIndexIterator<T>
 where
     T: Bitboard,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -178,17 +178,29 @@ impl Evaluator for Weights6 {
                 }
             }
         }
+        // Danger FOR the associated color
+        // const DANGER_MUL: i32 = 20; // 20
+        // let white_danger = (game.bits.road_pieces(Color::Black).critical_squares()
+        //     & !game.bits.blocker_pieces(Color::White))
+        // .pop_count() as i32;
+        // let black_danger = (game.bits.road_pieces(Color::White).critical_squares()
+        //     & !game.bits.blocker_pieces(Color::Black))
+        // .pop_count() as i32;
         let white_connectivity = (game.bits.white.adjacent() & game.bits.white).pop_count();
         let black_connectivity = (game.bits.black.adjacent() & game.bits.black).pop_count();
         score += white_connectivity as i32 * self.connectivity;
         score -= black_connectivity as i32 * self.connectivity;
         if let Color::White = game.side_to_move() {
+            // score -= DANGER_MUL * white_danger;
+            // score += DANGER_MUL * black_danger;
             if depth % 2 == 0 {
                 score
             } else {
                 score - self.tempo_offset
             }
         } else {
+            // score += DANGER_MUL * white_danger;
+            // score -= DANGER_MUL * black_danger;
             if depth % 2 == 0 {
                 -1 * score
             } else {

--- a/src/move_gen.rs
+++ b/src/move_gen.rs
@@ -3,10 +3,25 @@ use crate::board::TakBoard;
 use board_game_traits::Color;
 use std::fmt;
 
+mod move_order;
+pub use move_order::{KillerMoves, SmartMoveBuffer};
 pub mod ptn;
 
+pub trait MoveBuffer {
+    fn add_move(&mut self, mv: GameMove);
+    fn add_limit(&mut self, limit: MoveLimits);
+}
+
+impl MoveBuffer for Vec<GameMove> {
+    fn add_move(&mut self, mv: GameMove) {
+        self.push(mv);
+    }
+
+    fn add_limit(&mut self, _limit: MoveLimits) {}
+}
+
 /// Generates all legal moves in a position, filling the provided buffer
-pub fn generate_all_moves<T: TakBoard>(board: &T, moves: &mut Vec<GameMove>) {
+pub fn generate_all_moves<T: TakBoard, B: MoveBuffer>(board: &T, moves: &mut B) {
     generate_all_place_moves(board, moves);
     if board.move_num() >= 2 {
         generate_all_stack_moves(board, moves);
@@ -14,7 +29,7 @@ pub fn generate_all_moves<T: TakBoard>(board: &T, moves: &mut Vec<GameMove>) {
 }
 
 /// Generates all legal placements of flats, walls, and caps for the active player.
-pub fn generate_all_place_moves<T: TakBoard>(board: &T, moves: &mut Vec<GameMove>) {
+pub fn generate_all_place_moves<T: TakBoard, B: MoveBuffer>(board: &T, moves: &mut B) {
     let side_to_move = board.side_to_move();
     let start_locs = board.empty_tiles();
     if board.move_num() == 1 {
@@ -24,7 +39,7 @@ pub fn generate_all_place_moves<T: TakBoard>(board: &T, moves: &mut Vec<GameMove
             Color::Black => Piece::BlackFlat,
         };
         for index in start_locs {
-            moves.push(GameMove::from_placement(piece, index));
+            moves.add_move(GameMove::from_placement(piece, index));
         }
         return;
     }
@@ -34,12 +49,12 @@ pub fn generate_all_place_moves<T: TakBoard>(board: &T, moves: &mut Vec<GameMove
     };
     if board.caps_reserve(side_to_move) > 0 {
         for index in start_locs {
-            moves.push(GameMove::from_placement(cap, index));
+            moves.add_move(GameMove::from_placement(cap, index));
         }
     }
     for index in board.empty_tiles() {
-        moves.push(GameMove::from_placement(flat, index));
-        moves.push(GameMove::from_placement(wall, index));
+        moves.add_move(GameMove::from_placement(flat, index));
+        moves.add_move(GameMove::from_placement(wall, index));
     }
 }
 
@@ -64,7 +79,7 @@ pub fn generate_aggressive_place_moves<T: TakBoard>(board: &T, moves: &mut Vec<G
 }
 
 /// Generates all legal sliding movements for the active player's stacks.
-pub fn generate_all_stack_moves<T: TakBoard>(board: &T, moves: &mut Vec<GameMove>) {
+pub fn generate_all_stack_moves<T: TakBoard, B: MoveBuffer>(board: &T, moves: &mut B) {
     let start_locs = board.active_stacks(board.side_to_move());
     for index in start_locs {
         let stack_height = board.index(index).len();
@@ -80,25 +95,9 @@ pub fn generate_all_stack_moves<T: TakBoard>(board: &T, moves: &mut Vec<GameMove
             if max_steps == 0 {
                 continue;
             }
-            // Max steps is greater than zero, so we know we can move
-            let first_dest = match dir {
-                0 => index - T::SIZE,
-                1 => index + 1,
-                2 => index + T::SIZE,
-                3 => index - 1,
-                _ => unimplemented!(),
-            };
-            match board.index(first_dest).last() {
-                Some(piece) => {
-                    // Capture enemy piece first;
-                    if piece.owner() != board.side_to_move() {
-                        // dir_move = dir_move.add_score(3);
-                    }
-                }
-                _ => {}
-            }
             directional_stack_moves(moves, dir_move, max_steps, max_pieces);
         }
+        moves.add_limit(limits);
     }
 }
 
@@ -155,26 +154,6 @@ impl GameMove {
     /// In situations where a null move might arise, it must be checked for explicitly.
     pub fn null_move() -> Self {
         Self(0)
-    }
-    /// Returns the move priority directly embedded in the bits of the move.
-    ///
-    /// Importantly, the score bits must not be included in the hashing of game moves.
-    pub fn score(self) -> i32 {
-        let bits = self.0 >> 52;
-        if self.is_place_move() {
-            (bits + 3) as i32
-        } else {
-            (bits + self.number() + 10 * self.is_stack_move() as u64) as i32
-        }
-    }
-    /// Adds the provided value to the score.
-    ///
-    /// # Panics
-    ///
-    /// Note that only 12 bits are reserved for the score, so larger values will overflow, corrupting the data
-    /// and panicking in debug mode.
-    pub fn add_score(&mut self, score: u64) {
-        self.0 = self.0 + (score << 52)
     }
     /// Returns true if this is a placement move, i.e. not a stack move or null move.
     pub fn is_place_move(self) -> bool {
@@ -234,6 +213,10 @@ impl GameMove {
     /// amount to increment / decrement the index value by as the stack moves
     pub fn forward_iter(self, board_size: usize) -> StackMoveIterator {
         StackMoveIterator::new(self, board_size)
+    }
+    /// Returns an iterator that returns the quantity and board index for each stack step
+    fn quantity_iter(self, board_size: usize) -> QuantityMoveIterator {
+        QuantityMoveIterator::new(self, board_size)
     }
     fn set_tile(self, tile_num: usize, count: u64) -> Self {
         match tile_num {
@@ -355,6 +338,55 @@ impl Iterator for StackMoveIterator {
     }
 }
 
+struct QuantityMoveIterator {
+    slide_bits: u64,
+    direction: u8,
+    index: usize,
+    board_size: usize,
+}
+
+impl QuantityMoveIterator {
+    fn new(game_move: GameMove, board_size: usize) -> Self {
+        let slide_bits = game_move.slide_bits();
+        let direction = game_move.direction() as u8;
+        let index = game_move.src_index();
+        Self {
+            slide_bits,
+            direction,
+            index,
+            board_size,
+        }
+    }
+}
+
+impl Iterator for QuantityMoveIterator {
+    type Item = QuantityStep;
+    fn next(&mut self) -> Option<<Self as Iterator>::Item> {
+        if self.slide_bits == 0 {
+            return None;
+        }
+        let quantity = self.slide_bits & 0xF;
+        self.slide_bits = self.slide_bits >> 4;
+        match self.direction {
+            0 => self.index -= self.board_size,
+            1 => self.index += 1,
+            2 => self.index += self.board_size,
+            3 => self.index -= 1,
+            _ => unimplemented!(),
+        }
+        let step = QuantityStep {
+            index: self.index,
+            quantity,
+        };
+        Some(step)
+    }
+}
+
+struct QuantityStep {
+    index: usize,
+    quantity: u64,
+}
+
 pub struct RevStackMoveIterator {
     slide_bits: u64,
     direction: u8,
@@ -407,7 +439,7 @@ impl Iterator for RevStackMoveIterator {
 
 #[derive(Debug)]
 pub struct MoveLimits {
-    steps: [usize; 4],
+    steps: [u8; 4],
     can_crush: [bool; 4],
 }
 
@@ -492,10 +524,10 @@ fn step_west(row: usize, col: usize) -> (usize, usize) {
 
 /// Find all stack moves for a single stack in one direction. Calls the recursive
 /// function [recursive_stack_moves] 1..=pieces_available times.
-pub fn directional_stack_moves(
-    moves: &mut Vec<GameMove>,
+pub fn directional_stack_moves<B: MoveBuffer>(
+    moves: &mut B,
     init_move: GameMove,
-    max_move: usize,
+    max_move: u8,
     pieces_available: usize,
 ) {
     for take_pieces in 1..pieces_available as u64 + 1 {
@@ -515,15 +547,15 @@ pub fn directional_stack_moves(
 /// recursive function [recursive_crush_moves] for all legal initial stack sizes.
 /// This is more restrictive than the condition on [directional_stack_moves] because
 /// one flat must be placed for tile traversed.
-pub fn directional_crush_moves(
-    moves: &mut Vec<GameMove>,
+pub fn directional_crush_moves<B: MoveBuffer>(
+    moves: &mut B,
     init_move: GameMove,
-    max_steps: usize,
+    max_steps: u8,
     pieces_available: usize,
 ) {
-    let init_move = init_move.set_crush().set_tile(max_steps + 1, 1);
+    let init_move = init_move.set_crush().set_tile(max_steps as usize + 1, 1);
     if max_steps == 0 {
-        moves.push(init_move.set_number(1));
+        moves.add_move(init_move.set_number(1));
         return;
     }
     // Todo figure out upper bound for number of pieces to take to save some cycles?
@@ -538,16 +570,16 @@ pub fn directional_crush_moves(
     }
 }
 
-pub fn recursive_stack_moves(
-    moves: &mut Vec<GameMove>,
+pub fn recursive_stack_moves<B: MoveBuffer>(
+    moves: &mut B,
     in_progress: GameMove,
     tile_num: usize,
-    moves_left: usize,
+    moves_left: u8,
     pieces_left: u64,
 ) {
     if moves_left == 1 || pieces_left == 1 {
         let last_move = in_progress.set_tile(tile_num, pieces_left);
-        moves.push(last_move);
+        moves.add_move(last_move);
         return;
     }
     for piece_count in 1..pieces_left {
@@ -559,19 +591,19 @@ pub fn recursive_stack_moves(
             pieces_left - piece_count,
         );
     }
-    moves.push(in_progress.set_tile(tile_num, pieces_left));
+    moves.add_move(in_progress.set_tile(tile_num, pieces_left));
 }
 
-pub fn recursive_crush_moves(
-    moves: &mut Vec<GameMove>,
+pub fn recursive_crush_moves<B: MoveBuffer>(
+    moves: &mut B,
     in_progress: GameMove,
     tile_num: usize,
-    moves_left: usize,
+    moves_left: u8,
     pieces_left: u64,
 ) {
     if moves_left == 1 && pieces_left > 0 {
         let last_move = in_progress.set_tile(tile_num, pieces_left);
-        moves.push(last_move);
+        moves.add_move(last_move);
         return;
     }
     // Todo figure out max placement to save some cycles?
@@ -606,7 +638,7 @@ mod test {
 
         for stack_size in 4..7 {
             moves.clear();
-            directional_stack_moves(&mut moves, GameMove(0), stack_size, stack_size);
+            directional_stack_moves(&mut moves, GameMove(0), stack_size, stack_size as usize);
             assert_eq!(moves.len(), 2usize.pow(stack_size as u32) - 1);
         }
 

--- a/src/move_gen.rs
+++ b/src/move_gen.rs
@@ -102,7 +102,7 @@ pub fn generate_all_stack_moves<T: TakBoard, B: MoveBuffer>(board: &T, moves: &m
 }
 
 /// A struct containing the necessary data to reverse a [GameMove].
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RevGameMove {
     pub game_move: GameMove,
     pub dest_sq: usize,

--- a/src/move_gen.rs
+++ b/src/move_gen.rs
@@ -4,7 +4,7 @@ use board_game_traits::Color;
 use std::fmt;
 
 mod move_order;
-pub use move_order::{KillerMoves, SmartMoveBuffer};
+pub use move_order::{HistoryMoves, KillerMoves, SmartMoveBuffer};
 pub mod ptn;
 
 pub trait MoveBuffer {

--- a/src/move_gen/move_order.rs
+++ b/src/move_gen/move_order.rs
@@ -3,7 +3,7 @@ use crate::search::SearchInfo;
 
 pub struct SmartMoveBuffer {
     moves: Vec<ScoredMove>,
-    limits: Vec<MoveLimits>,
+    stack_hist: Vec<i16>,
     queries: usize,
 }
 
@@ -11,15 +11,16 @@ impl SmartMoveBuffer {
     pub fn new() -> Self {
         Self {
             moves: Vec::new(),
-            limits: Vec::new(),
+            stack_hist: vec![0; 36],
             queries: 0,
         }
     }
-    pub fn score_stack_moves<T: TakBoard>(&mut self, board: &T) {
+    pub fn score_stack_moves<T: TakBoard>(&mut self, board: &T, last_capture: Option<RevGameMove>) {
+        // let DEBUG: &'static str = "5b2>221";
         let active_side = board.side_to_move();
         let mut stack_idx = usize::MAX;
         // Moves should be grouped by src index due to generator impl
-        let mut stack_data = [Piece::WhiteFlat; 8];
+        let mut stack_data = [Piece::WhiteFlat; 8]; // Todo T::SIZE + 1 when rust figures out this valid
         for x in self.moves.iter_mut().filter(|x| x.mv.is_stack_move()) {
             let mut score = 0;
             let src_idx = x.mv.src_index();
@@ -27,16 +28,31 @@ impl SmartMoveBuffer {
             if src_idx != stack_idx {
                 stack_idx = src_idx;
                 // Update stack data
-                let number = x.mv.number() as usize;
-                for i in 0..number {
-                    stack_data[i] = board.index(src_idx).from_top(i).unwrap();
+                // let number = x.mv.number() as usize;
+                let stack = board.index(src_idx);
+                let limit = std::cmp::min(stack.len(), T::SIZE);
+                for i in 0..limit {
+                    stack_data[limit - i] = stack.from_top(i).unwrap();
+                }
+                if let Some(piece) = stack.from_top(limit) {
+                    stack_data[0] = piece;
                 }
             }
+            // if &x.mv.to_ptn::<T>() == "6b6>1113" {
+            //     panic!()
+            //     // println!("{}", "HELLO \n \n \n \n ");
+            // }
             let mut offset = 0;
             for step in x.mv.quantity_iter(T::SIZE) {
+                debug_assert!(step.quantity > 0);
                 offset += step.quantity as usize;
                 let covered = board.index(step.index).last();
                 let covering = stack_data[offset];
+                // println!("{}", &x.mv.to_ptn::<T>());
+                // if &x.mv.to_ptn::<T>() == DEBUG {
+                //     println!("Covered: {:?}", covered);
+                //     println!("Covering {:?}", covering);
+                // }
                 if let Some(piece) = covered {
                     if piece.owner() == active_side {
                         score -= 1;
@@ -45,10 +61,36 @@ impl SmartMoveBuffer {
                     }
                 }
                 if covering.owner() == active_side {
+                    // if let Some(capture) = last_capture {
+                    //     if step.index == capture.dest_sq {
+                    //         score += 3;
+                    //     }
+                    // }
+                    score += 2;
+                } else {
+                    score -= 2;
+                }
+            }
+            let src_stack = board.index(src_idx);
+            if let Some(piece) = src_stack.from_top(x.mv.number() as usize) {
+                if piece.owner() == active_side {
+                    score += 2;
+                } else {
+                    score -= 2;
+                }
+            }
+            if let Some(piece) = src_stack.last() {
+                if piece.is_cap() {
                     score += 1;
+                    if x.mv.crush() {
+                        score += 1;
+                    }
                 }
             }
             x.score += score;
+            // if &x.mv.to_ptn::<T>() == DEBUG {
+            //     dbg!(x.score);
+            // }
         }
     }
     pub fn score_pv_move(&mut self, pv_move: GameMove) {
@@ -69,15 +111,31 @@ impl SmartMoveBuffer {
                 .moves
                 .iter()
                 .enumerate()
-                .max_by_key(|(_i, &m)| m.score + info.killer_moves[depth].score(m.mv) as i16)
+                .max_by_key(|(_i, &m)| {
+                    m.score + info.killer_moves[depth].score(m.mv) as i16
+                        - self.stack_hist_score(m.mv)
+                })
                 .unwrap();
             let m = *m;
+            if m.mv.is_stack_move() {
+                let hist_score = &mut self.stack_hist[m.mv.src_index()];
+                if *hist_score < 10 {
+                    *hist_score += 1;
+                }
+            }
             self.moves.swap_remove(idx);
             m.mv
         } else {
             // Probably an all node, so search order doesn't really matter
             let x = self.moves.pop().unwrap();
             x.mv
+        }
+    }
+    fn stack_hist_score(&self, mv: GameMove) -> i16 {
+        if mv.is_stack_move() {
+            self.stack_hist[mv.src_index()]
+        } else {
+            0
         }
     }
     pub fn len(&self) -> usize {
@@ -103,12 +161,12 @@ impl MoveBuffer for SmartMoveBuffer {
         if mv.is_place_move() {
             self.moves.push(ScoredMove::new(mv, 3));
         } else {
-            self.moves.push(ScoredMove::new(mv, mv.number() as i16));
+            self.moves.push(ScoredMove::new(mv, 0));
         }
     }
 
-    fn add_limit(&mut self, limit: MoveLimits) {
-        self.limits.push(limit);
+    fn add_limit(&mut self, _limit: MoveLimits) {
+        // self.limits.push(limit);
     }
 }
 
@@ -136,6 +194,28 @@ impl KillerMoves {
             80
         } else {
             0
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::Board6;
+    #[test]
+    fn big_stack_order() {
+        let tps = "21C,222222,2,x3/2,2,2S,12121S,x,2/2,2,1,1,1,1/x,1S,111112C,1,1,x/1,12112S,x4/x,2,x3,1 2 31";
+        let board = Board6::try_from_tps(tps).unwrap();
+        let mut moves = SmartMoveBuffer::new();
+        generate_all_moves(&board, &mut moves);
+        moves.score_stack_moves(&board, None);
+        moves.moves.sort_by_key(|x| -x.score);
+        assert!(moves.moves[0].score >= moves.moves.last().unwrap().score);
+        let info = SearchInfo::new(1, 0);
+        let order = (0..moves.moves.len()).map(|_| moves.get_best(0, &info));
+        // let order: Vec<_> = moves.moves.into_iter().map(|x| *x.mv).collect();
+        for m in order {
+            println!("{}", m.to_ptn::<Board6>());
         }
     }
 }

--- a/src/move_gen/move_order.rs
+++ b/src/move_gen/move_order.rs
@@ -1,0 +1,141 @@
+use super::*;
+use crate::search::SearchInfo;
+
+pub struct SmartMoveBuffer {
+    moves: Vec<ScoredMove>,
+    limits: Vec<MoveLimits>,
+    queries: usize,
+}
+
+impl SmartMoveBuffer {
+    pub fn new() -> Self {
+        Self {
+            moves: Vec::new(),
+            limits: Vec::new(),
+            queries: 0,
+        }
+    }
+    pub fn score_stack_moves<T: TakBoard>(&mut self, board: &T) {
+        let active_side = board.side_to_move();
+        let mut stack_idx = usize::MAX;
+        // Moves should be grouped by src index due to generator impl
+        let mut stack_data = [Piece::WhiteFlat; 8];
+        for x in self.moves.iter_mut().filter(|x| x.mv.is_stack_move()) {
+            let mut score = 0;
+            let src_idx = x.mv.src_index();
+            // TODO figure out if this is right
+            if src_idx != stack_idx {
+                stack_idx = src_idx;
+                // Update stack data
+                let number = x.mv.number() as usize;
+                for i in 0..number {
+                    stack_data[i] = board.index(src_idx).from_top(i).unwrap();
+                }
+            }
+            let mut offset = 0;
+            for step in x.mv.quantity_iter(T::SIZE) {
+                offset += step.quantity as usize;
+                let covered = board.index(step.index).last();
+                let covering = stack_data[offset];
+                if let Some(piece) = covered {
+                    if piece.owner() == active_side {
+                        score -= 1;
+                    } else {
+                        score += 1;
+                    }
+                }
+                if covering.owner() == active_side {
+                    score += 1;
+                }
+            }
+            x.score += score;
+        }
+    }
+    pub fn score_pv_move(&mut self, pv_move: GameMove) {
+        if let Some(found) = self.moves.iter_mut().find(|m| m.mv == pv_move) {
+            found.score += 100;
+        }
+    }
+    pub fn score_tak_threats(&mut self, tak_threats: &[GameMove]) {
+        for m in self.moves.iter_mut() {
+            if tak_threats.contains(&m.mv) {
+                m.score += 50;
+            }
+        }
+    }
+    pub fn get_best(&mut self, depth: usize, info: &SearchInfo) -> GameMove {
+        if self.queries <= 10 {
+            let (idx, m) = self
+                .moves
+                .iter()
+                .enumerate()
+                .max_by_key(|(_i, &m)| m.score + info.killer_moves[depth].score(m.mv) as i16)
+                .unwrap();
+            let m = *m;
+            self.moves.swap_remove(idx);
+            m.mv
+        } else {
+            // Probably an all node, so search order doesn't really matter
+            let x = self.moves.pop().unwrap();
+            x.mv
+        }
+    }
+    pub fn len(&self) -> usize {
+        self.moves.len()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ScoredMove {
+    mv: GameMove,
+    score: i16,
+}
+
+impl ScoredMove {
+    fn new(mv: GameMove, score: i16) -> Self {
+        Self { mv, score }
+    }
+}
+
+impl MoveBuffer for SmartMoveBuffer {
+    fn add_move(&mut self, mv: GameMove) {
+        // (bits + self.number() + 10 * self.is_stack_move() as u64)
+        if mv.is_place_move() {
+            self.moves.push(ScoredMove::new(mv, 3));
+        } else {
+            self.moves.push(ScoredMove::new(mv, mv.number() as i16));
+        }
+    }
+
+    fn add_limit(&mut self, limit: MoveLimits) {
+        self.limits.push(limit);
+    }
+}
+
+#[derive(Clone)]
+pub struct KillerMoves {
+    killer1: GameMove,
+    killer2: GameMove,
+}
+
+impl KillerMoves {
+    pub fn new() -> Self {
+        KillerMoves {
+            killer1: GameMove::null_move(),
+            killer2: GameMove::null_move(),
+        }
+    }
+    pub fn add(&mut self, game_move: GameMove) {
+        self.killer2 = self.killer1;
+        self.killer1 = game_move;
+    }
+    pub fn score(&self, game_move: GameMove) -> i32 {
+        if self.killer1 == game_move {
+            90
+        } else if self.killer2 == game_move {
+            80
+        } else {
+            0
+        }
+    }
+}

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -269,8 +269,9 @@ impl TimeLeft {
 }
 
 fn play_game_tei(receiver: Receiver<TeiCommand>) -> Result<()> {
+    const MAX_DEPTH: usize = 8;
     let mut board = Board6::new();
-    let mut info = SearchInfo::new(6, 1000000);
+    let mut info = SearchInfo::new(MAX_DEPTH, 1000000);
     let mut eval = Weights6::default();
     eval.add_noise();
     // let eval = Evaluator6 {};
@@ -285,7 +286,7 @@ fn play_game_tei(receiver: Receiver<TeiCommand>) -> Result<()> {
                 let est_plies = low_flats * 2;
                 let time_left = TimeLeft::new(&s);
                 let use_time = time_left.use_time(est_plies, board.side_to_move());
-                info = SearchInfo::new(6, 0)
+                info = SearchInfo::new(MAX_DEPTH, 0)
                     .take_table(&mut info)
                     .max_time(use_time);
                 let res = search(&mut board, &eval, &mut info);

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -32,6 +32,7 @@ pub fn main() {
             // println!("Computer Choose: {}", pv_move.to_ptn::<Board6>());
             // info.print_cuts();
             // let node_counts = search_efficiency(&["empty6"], 8);
+            // let node_counts = search_efficiency(&["midgame1"], 6);
             let node_counts = search_efficiency(&["alion1", "alion2", "alion3", "topaz1"], 6);
             let nodes: usize = node_counts.into_iter().sum();
             println!(
@@ -110,6 +111,7 @@ fn saved_tps(name: &str) -> Option<&str> {
         "test7" => concat!("2,2,21S,2,1,1,1/2,1,x,2,1,x,1/2,2,2,2,21112C,121S,x/x2,1112C,2,1,1112S,x/121,22211C,", 
             "1S,1,1,121,1221C/x,2,2,2,1,12,2/2,x3,1,122,x 2 50"),
         "topaz1" => "x2,1,x,1212,x/x,221,2212221211C,2S,x2/x,221,1,2,2,x/221,2,12C,1,2,2/22221S,221S,1,1,2,x/12,x,12,1,1,x 1 44",
+        "midgame1" => "2,2,2222221C,x3/2,2,2S,12121S,x,2/2,2,1,1,1,1/x,1S,111112C,1,1,x/1,12112S,x4/x,2,x3,1 1 31", // Tinue avoidance
         _ => {return None}
     };
     Some(s)

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -272,8 +272,8 @@ fn play_game_tei(receiver: Receiver<TeiCommand>) -> Result<()> {
     const MAX_DEPTH: usize = 8;
     let mut board = Board6::new();
     let mut info = SearchInfo::new(MAX_DEPTH, 1000000);
-    let mut eval = Weights6::default();
-    eval.add_noise();
+    let eval = Weights6::default();
+    // eval.add_noise();
     // let eval = Evaluator6 {};
     loop {
         let message = receiver.recv()?;


### PR DESCRIPTION
Add simple to calculate but relatively useful stack safety and mobility heuristics. Change the way connectivity is scored, preferring fewer connected components rather than more pieces with friendly neighbors. 

With the better eval in place, begin to investigate smarter ways of move ordering. This pull request only improves stack moves. It expends some extra processing time, but it makes the stack move ordering much better, favoring moves which positively affect the number of squares controlled. 

Also play around with some history heuristics including a "negative history heuristic" for stack moves. This is pretty experimental and overall strength doesn't seem greatly changed for better or worse. 