### PR TITLE
search improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ dotenv = "0.15.0"
 
 [profile.release]
 debug = true
+lto = true
 
 [dev-dependencies]
 criterion = "0.3"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -3,17 +3,22 @@ use topaz_tak::board::find_placement_road;
 use topaz_tak::board::{Bitboard6, Board6};
 use topaz_tak::eval::{Evaluator, Evaluator6, LOSE_SCORE};
 use topaz_tak::search::root_minimax;
-use topaz_tak::{execute_moves_check_valid, perft, Color, GameMove};
+use topaz_tak::{execute_moves_check_valid, generate_all_moves, perft, Color, GameMove, TakBoard};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("small perft", |b| {
-        b.iter(|| execute_small_perft(black_box(2)))
-    });
+    // c.bench_function("small perft", |b| {
+    //     b.iter(|| execute_small_perft(black_box(2)))
+    // });
+    let mut pos = get_positions();
+    let mut legal = vec![Vec::new(); pos.len()];
+    for (board, moves) in pos.iter().zip(legal.iter_mut()) {
+        generate_all_moves(board, moves)
+    }
     // let pos = get_positions();
     // let eval = Evaluator6 {};
-    // c.bench_function("eval", |b| {
-    //     b.iter(|| evaluate_positions(black_box(&pos), black_box(&eval)))
-    // });
+    c.bench_function("tak_threat", |b| {
+        b.iter(|| check_for_tak(black_box(&mut pos), black_box(&mut legal)))
+    });
 }
 
 fn execute_small_perft(depth: usize) {
@@ -29,6 +34,12 @@ fn execute_small_perft(depth: usize) {
         .collect();
     // assert_eq!(&p_res[..], &[1, 190, 20698]);
     assert_eq!(&p_res[..], &[1, 190, 20698]);
+}
+
+fn check_for_tak(boards: &mut [Board6], legal_moves: &[Vec<GameMove>]) {
+    for (board, moves) in boards.into_iter().zip(legal_moves.iter()) {
+        board.get_tak_threats(&moves, None);
+    }
 }
 
 fn get_positions() -> Vec<Board6> {

--- a/src/board.rs
+++ b/src/board.rs
@@ -280,12 +280,13 @@ macro_rules! board_impl {
                 road_pieces: <Self as TakBoard>::Bits,
                 stack_move: GameMove,
             ) -> bool {
+                // todo!();
                 let color = self.active_player();
                 let src_sq = stack_move.src_index();
                 let dir = stack_move.direction();
                 let stack = &self.board[src_sq];
-                let mut pickup = stack_move.number();
-                let mut slide_bits = stack_move.slide_bits();
+                let mut pickup = stack_move.number() as u64;
+                let mut slide_bits = stack_move.large_slide_bits();
                 let mut update = <Self as TakBoard>::Bits::ZERO;
                 let mut index = src_sq;
                 let mut mask = <Self as TakBoard>::Bits::index_to_bit(index);

--- a/src/board.rs
+++ b/src/board.rs
@@ -280,34 +280,22 @@ macro_rules! board_impl {
                 road_pieces: <Self as TakBoard>::Bits,
                 stack_move: GameMove,
             ) -> bool {
-                // todo!();
                 let color = self.active_player();
                 let src_sq = stack_move.src_index();
-                let dir = stack_move.direction();
                 let stack = &self.board[src_sq];
-                let mut pickup = stack_move.number() as u64;
-                let mut slide_bits = stack_move.large_slide_bits();
+                let mut pickup = stack_move.number() as u32;
                 let mut update = <Self as TakBoard>::Bits::ZERO;
-                let mut index = src_sq;
-                let mut mask = <Self as TakBoard>::Bits::index_to_bit(index);
+                let mut mask = <Self as TakBoard>::Bits::index_to_bit(src_sq);
                 let val = stack
                     .from_top(pickup as usize)
                     .map(|p| p.road_piece(color))
                     .unwrap_or(false); // Could have taken all pieces
                 if val {
-                    update |= <Self as TakBoard>::Bits::index_to_bit(index);
+                    update |= <Self as TakBoard>::Bits::index_to_bit(src_sq);
                 }
-                while slide_bits != 0 {
-                    match dir {
-                        0 => index -= Self::SIZE,
-                        1 => index += 1,
-                        2 => index += Self::SIZE,
-                        3 => index -= 1,
-                        _ => unimplemented!(),
-                    }
-                    pickup -= slide_bits & 0xF;
-                    slide_bits = slide_bits >> 4;
-                    let bb = <Self as TakBoard>::Bits::index_to_bit(index);
+                for qstep in stack_move.quantity_iter(Self::SIZE) {
+                    pickup -= qstep.quantity;
+                    let bb = <Self as TakBoard>::Bits::index_to_bit(qstep.index);
                     mask |= bb;
                     let val = stack
                         .from_top(pickup as usize)

--- a/src/board.rs
+++ b/src/board.rs
@@ -385,7 +385,7 @@ macro_rules! board_impl {
                     if rev_m.game_move.crush() {
                         // Stand the wall back up
                         let dest_tile = &mut self.board[rev_m.dest_sq];
-                        dest_tile.uncrush_wall(&mut self.bits);
+                        dest_tile.uncrush_wall::<<Self as TakBoard>::Bits>();
                     }
                     let iter = rev_m.rev_iter(Self::SIZE);
                     // We need to get a mutable reference to multiple areas of the array. Hold on.
@@ -443,7 +443,7 @@ macro_rules! board_impl {
                     let last_square = &mut self.board[last_idx];
                     let len = last_square.len();
                     if len >= 2 {
-                        if last_square.try_crush_wall(&mut self.bits) {
+                        if last_square.try_crush_wall::<<Self as TakBoard>::Bits>() {
                             return RevGameMove::new(m.set_crush(), last_idx);
                         }
                     }

--- a/src/board/piece.rs
+++ b/src/board/piece.rs
@@ -11,7 +11,7 @@ pub enum Piece {
 }
 
 impl Piece {
-    pub fn from_index(index: u64) -> Self {
+    pub fn from_index(index: u32) -> Self {
         match index {
             1 => Piece::WhiteFlat,
             2 => Piece::WhiteWall,

--- a/src/board/stack.rs
+++ b/src/board/stack.rs
@@ -64,7 +64,7 @@ impl Stack {
             self.push(item, bits);
         }
     }
-    pub fn try_crush_wall<T: Bitboard>(&mut self, bits: &mut BitboardStorage<T>) -> bool {
+    pub fn try_crush_wall<T: Bitboard>(&mut self) -> bool {
         if self.len() >= 2 {
             let wall_idx = self.len() - 2;
             if let Some(crushed) = self.data[wall_idx].crush() {
@@ -74,7 +74,7 @@ impl Stack {
         }
         false
     }
-    pub fn uncrush_wall<T: Bitboard>(&mut self, bits: &mut BitboardStorage<T>) {
+    pub fn uncrush_wall<T: Bitboard>(&mut self) {
         if self.len() >= 2 {
             let wall_idx = self.len() - 2;
             if let Some(uncrushed) = self.data[wall_idx].uncrush() {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -83,6 +83,7 @@ pub const LOSE_SCORE: i32 = -1 * WIN_SCORE;
 
 impl Evaluator for Weights6 {
     type Game = Board6;
+    #[inline(never)]
     fn evaluate(&self, game: &Self::Game, depth: usize) -> i32 {
         let mut score = 0;
         // let white_res = game.pieces_reserve(Color::White) as i32;
@@ -92,7 +93,7 @@ impl Evaluator for Weights6 {
         // flat_diff *= 2;
         // flat_diff -= game.komi() as i32;
         // let white_res_lead = black_res - white_res;
-        // let white_leading = white_res_lead >= 4 && 
+        // let white_leading = white_res_lead >= 4 &&
 
         for (idx, stack) in game.board.iter().enumerate() {
             if stack.len() == 1 {
@@ -192,7 +193,7 @@ impl Evaluator for Weights6 {
             score -= 30;
         }
 
-        
+
         // // Danger FOR the associated color
         // const DANGER_MUL: i32 = 40; // 20
         // let white_danger = (game.bits.road_pieces(Color::Black).critical_squares()
@@ -478,7 +479,7 @@ const LOCATION_WEIGHT: [i32; 36] = [
     05, 15, 20, 20, 15, 05,
     05, 15, 20, 20, 15, 05,
     05, 10, 15, 15, 10, 05,
-    00, 05, 05, 05, 05, 00, 
+    00, 05, 05, 05, 05, 00,
 ];
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub use board_game_traits::{Color, GameResult, Position};
 pub use move_gen::{generate_all_moves, GameMove, RevGameMove};
 
 pub mod board;
+pub mod transposition_table;
 pub mod eval;
 mod move_gen;
 pub mod search;

--- a/src/move_gen.rs
+++ b/src/move_gen.rs
@@ -540,7 +540,6 @@ pub fn directional_stack_moves<B: MoveBuffer>(
         recursive_stack_moves(
             moves,
             init_move.set_number(take_pieces),
-            1,
             max_move,
             take_pieces,
         );
@@ -570,7 +569,6 @@ pub fn directional_crush_moves<B: MoveBuffer>(
         recursive_crush_moves(
             moves,
             init_move.set_number(take_pieces + 1),
-            1,
             max_steps,
             take_pieces,
         );
@@ -580,7 +578,6 @@ pub fn directional_crush_moves<B: MoveBuffer>(
 pub fn recursive_stack_moves<B: MoveBuffer>(
     moves: &mut B,
     in_progress: GameMove,
-    tile_num: usize,
     moves_left: u8,
     pieces_left: u32,
 ) {
@@ -593,7 +590,6 @@ pub fn recursive_stack_moves<B: MoveBuffer>(
         recursive_stack_moves(
             moves,
             in_progress.set_next_tile(piece_count),
-            tile_num + 1,
             moves_left - 1,
             pieces_left - piece_count,
         );
@@ -604,7 +600,6 @@ pub fn recursive_stack_moves<B: MoveBuffer>(
 pub fn recursive_crush_moves<B: MoveBuffer>(
     moves: &mut B,
     in_progress: GameMove,
-    tile_num: usize,
     moves_left: u8,
     pieces_left: u32,
 ) {
@@ -619,7 +614,6 @@ pub fn recursive_crush_moves<B: MoveBuffer>(
         recursive_crush_moves(
             moves,
             in_progress.set_next_tile(piece_count),
-            tile_num + 1,
             moves_left - 1,
             pieces_left - piece_count,
         );
@@ -663,11 +657,11 @@ mod test {
     #[test]
     pub fn single_direction_move() {
         let mut moves = Vec::new();
-        recursive_stack_moves(&mut moves, GameMove(0), 1, 3, 3);
+        recursive_stack_moves(&mut moves, GameMove(0), 3, 3);
         assert_eq!(moves.len(), 4);
-        recursive_stack_moves(&mut moves, GameMove(0), 1, 3, 2);
+        recursive_stack_moves(&mut moves, GameMove(0), 3, 2);
         assert_eq!(moves.len(), 4 + 2);
-        recursive_stack_moves(&mut moves, GameMove(0), 1, 3, 1);
+        recursive_stack_moves(&mut moves, GameMove(0), 3, 1);
         assert_eq!(moves.len(), 4 + 2 + 1);
 
         for stack_size in 4..7 {
@@ -677,7 +671,7 @@ mod test {
         }
 
         moves.clear();
-        recursive_crush_moves(&mut moves, GameMove(0), 1, 1, 2);
+        recursive_crush_moves(&mut moves, GameMove(0), 1, 2);
         assert_eq!(moves.len(), 1);
     }
     #[test]
@@ -708,6 +702,7 @@ mod test {
         generate_all_moves(board, &mut vec);
         vec
     }
+    #[allow(dead_code)]
     fn compare_move_lists<T: TakBoard>(my_moves: Vec<GameMove>, source_file: &str) {
         use std::collections::HashSet;
         let file_data = std::fs::read_to_string(source_file).unwrap();

--- a/src/move_gen/move_order.rs
+++ b/src/move_gen/move_order.rs
@@ -175,14 +175,16 @@ impl SmartMoveBuffer {
             }
         }
     }
-    pub fn get_best(&mut self, depth: usize, info: &SearchInfo) -> GameMove {
+
+    pub fn get_best(&mut self, ply: usize, info: &SearchInfo) -> GameMove {
         if self.queries <= 16 {
+            self.queries += 1;
             let (idx, m) = self
                 .moves
                 .iter()
                 .enumerate()
                 .max_by_key(|(_i, &m)| {
-                    m.score + info.killer_moves[depth].score(m.mv) as i16
+                    m.score + info.killer_moves[ply % info.max_depth].score(m.mv) as i16
                         - self.stack_hist_score(m.mv)
                 })
                 .unwrap();

--- a/src/move_gen/move_order.rs
+++ b/src/move_gen/move_order.rs
@@ -163,9 +163,14 @@ impl SmartMoveBuffer {
         // let neighbors = T::Bits::index_to_bit(idx).adjacent();
         // todo!()
     }
+    pub fn remove(&mut self, mv: GameMove) {
+        if let Some(pos) = self.moves.iter().position(|m| m.mv == mv) {
+            self.moves.remove(pos);
+        }
+    }
     pub fn score_pv_move(&mut self, pv_move: GameMove) {
         if let Some(found) = self.moves.iter_mut().find(|m| m.mv == pv_move) {
-            found.score += 1000;
+            found.score += 250;
         }
     }
     pub fn score_tak_threats(&mut self, tak_threats: &[GameMove]) {
@@ -175,7 +180,13 @@ impl SmartMoveBuffer {
             }
         }
     }
-
+    pub fn score_wins(&mut self, winning_moves: &[GameMove]) {
+        for m in self.moves.iter_mut() {
+            if winning_moves.contains(&m.mv) {
+                m.score += 1000
+            }
+        }
+    }
     pub fn get_best(&mut self, ply: usize, info: &SearchInfo) -> GameMove {
         if self.queries <= 16 {
             self.queries += 1;

--- a/src/move_gen/ptn.rs
+++ b/src/move_gen/ptn.rs
@@ -20,7 +20,8 @@ impl GameMove {
             3 => "<",
             _ => unimplemented!(),
         };
-        let spread_bits = self.large_slide_bits();
+        let spread_bits = self.sparse_slide_bits();
+        debug_assert_eq!(spread_bits, crate::move_gen::long_slide(self));
         // let spread_bits = 0;
         // todo!();
         let spread = format!("{:X}", spread_bits);

--- a/src/move_gen/ptn.rs
+++ b/src/move_gen/ptn.rs
@@ -155,7 +155,6 @@ impl GameMove {
         if let Some(dir) = iter.next() {
             // Stack Move
             let pieces = pieces.unwrap_or(1) as u32;
-            dbg!(pieces);
             let dir = match dir {
                 '+' => 0,
                 '>' => 1,
@@ -183,15 +182,7 @@ impl GameMove {
             if counter == 0 {
                 mv = mv.set_next_tile(mv.number());
             }
-            dbg!(mv);
             Some(mv)
-            // Some(
-            //     Self(slide_bits << 12)
-            //         .set_number(pieces)
-            //         .set_direction(dir)
-            //         .chain_crush(crush)
-            //         .set_index(square as u64),
-            // )
         } else {
             // Placement
             let color = active_player;

--- a/src/search.rs
+++ b/src/search.rs
@@ -738,17 +738,18 @@ where
 
             // late move reduction
             if LMR_ENABLED
-            && depth > LMR_DEPTH_LIMIT
-            && count >= LMR_FULL_SEARCH_MOVES
-            && (LMR_REDUCE_PV || !is_pv)
-            && (LMR_REDUCE_ROOT || !is_root)
+                && depth > LMR_DEPTH_LIMIT
+                && count >= LMR_FULL_SEARCH_MOVES
+                && (LMR_REDUCE_PV || !is_pv)
+                && (LMR_REDUCE_ROOT || !is_root)
             {
                 reduced_depth -= 2;
                 needs_re_search_on_alpha = true;
             }
             if PV_SEARCH_ENABLED
-            && depth > 1
-            && !data.is_root {
+                && depth > 1
+                && !data.is_root
+            {
                 next_alpha = -(alpha+1);
                 needs_re_search_on_alpha_beta = true;
             }
@@ -772,7 +773,8 @@ where
 
             // re-search full depth moves and those that don't fail low
             if needs_re_search_on_alpha
-            && score > alpha {
+                && score > alpha
+            {
                 score = -1 * alpha_beta(
                     board,
                     evaluator,
@@ -793,9 +795,10 @@ where
 
             // research with full windows if PV-Search doesn't fail
             if needs_re_search_on_alpha_beta
-            && score > alpha
-            && score < beta
-            && (PV_RE_SEARCH_NON_PV || data.is_pv) {
+                && score > alpha
+                && score < beta
+                && (PV_RE_SEARCH_NON_PV || data.is_pv)
+            {
                 score = -1 * alpha_beta(
                     board,
                     evaluator,

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -393,7 +393,7 @@ fn tei_loop() {
     let (sender, r) = unbounded();
     let mut receiver = Some(r);
     let mut buffer = String::new();
-    let mut init = GameInitializer::new(2<<22, 80, 0, false);
+    let mut init = GameInitializer::new(2 << 22, 80, 0, false);
     identify();
     loop {
         std::io::stdin()

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -367,6 +367,7 @@ fn play_game_tei(receiver: Receiver<TeiCommand>, init: GameInitializer) -> Resul
                 }
             }
             TeiCommand::NewGame(_size) => {
+                info.clear_tt();
                 if init.add_noise {
                     println!("Adding noise!");
                     eval.add_noise();

--- a/src/transposition_table.rs
+++ b/src/transposition_table.rs
@@ -1,0 +1,189 @@
+use crate::GameMove;
+
+// transposition table parameters
+const TT_BUCKET_SIZE: usize = 2; // how many HashEntries for each HashTable slot
+                                 // TT_BUCKET_SIZE *
+const TT_DISCARD_AGE: u8 = 5;  // adjusts which HashEntries are considered outdated
+
+// transposition table
+// implemented as hashtable with buckets
+//
+// key is computed with low bytes of zobrist hash of position
+// for each key, there is a bucket with TT_BUCKET_SIZE entries
+//
+// when a position is put in, an entry to replace is heuristically selected
+// from the bucket
+pub struct HashTable {
+    size: usize,
+    buckets: Vec<HashBucket>,
+}
+
+impl HashTable {
+    pub fn new(size: usize) -> Self {
+        println!("size of entry : {}", std::mem::size_of::<HashEntry>());
+        println!("size of bucket: {}", std::mem::size_of::<HashBucket>());
+        Self {
+            size: size / TT_BUCKET_SIZE,
+            buckets: vec![HashBucket::new(); size/TT_BUCKET_SIZE],
+        }
+    }
+
+    pub fn clear(&mut self) {
+        for i in 0..self.size {
+            for e_i in 0..TT_BUCKET_SIZE {
+                self.buckets[i].entries[e_i] = HashEntry::empty();
+            }
+        }
+    }
+
+    pub fn occupancy(&self) -> usize {
+        let mut hits = 0;
+        for i in 0..1000 {
+            let bucket = &self.buckets[i];
+            for e_i in 0..TT_BUCKET_SIZE {
+                if bucket.entries[e_i].ply > 0 {
+                    hits += 1;
+                }
+            }
+        }
+        hits = hits / 3;
+        hits
+    }
+
+    // put for 2 way hash table (bucket size == 2)
+    pub fn put(&mut self, hash: u64, entry: HashEntry) {
+        let bucket = &mut self.buckets[hash as usize % self.size];
+        let depth_entry = bucket.entries[0];
+        if entry.depth() > depth_entry.depth() ||
+            entry.depth() + entry.ply > depth_entry.depth() + depth_entry.ply + TT_DISCARD_AGE
+        {
+            bucket.entries[0] = entry;
+        } else {
+            bucket.entries[1] = entry;
+        }
+    }
+
+    // put for arbitrary bucket size
+    pub fn put_any(&mut self, hash: u64, entry: HashEntry) {
+        let slot: usize = hash as usize % self.size;
+        let bucket = &mut self.buckets[slot];
+
+        let mut worst_idx = 1;
+        let mut worst_score = 10000;
+        for i in 0..TT_BUCKET_SIZE {
+            let cur_entry = bucket.entries[i];
+            // replace same position if possible
+            if cur_entry.check_hash(hash) {
+                if entry.depth() > cur_entry.depth() {
+                    bucket.entries[i] = entry;
+                }
+                return;
+            }
+            let score = (cur_entry.depth() as usize) + (cur_entry.ply as usize);
+            if score < worst_score {
+                worst_score = score;
+                worst_idx = i;
+            }
+        }
+        bucket.entries[worst_idx] = entry;
+    }
+
+    pub fn get(&self, hash: &u64) -> Option<&HashEntry> {
+        let slot: usize = *hash as usize % self.size;
+        let hash_hi: u16 = (*hash >> 48) as u16;
+        for i in 0..TT_BUCKET_SIZE {
+            if self.buckets[slot].entries[i].hash_hi == hash_hi && self.buckets[slot].entries[i].game_move != GameMove::null_move() {
+                return Some(&self.buckets[slot].entries[i]);
+            }
+        }
+        None
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(align(32))]
+struct HashBucket {
+    entries: [HashEntry; TT_BUCKET_SIZE],
+}
+
+impl HashBucket {
+    fn new() -> Self {
+        Self {
+            entries: [HashEntry::empty(); TT_BUCKET_SIZE],
+        }
+    }
+}
+
+// right now this totals to 16 bytes, extended to 24 bytes for 8 byte memory alignment.
+// it would be nice to get this into 16 bytes!
+// this would be not only mean less memory usage, but also be much faster because of
+// cache utilization. each slot (2 entries) would be loaded with a single cache line.
+#[derive(Clone, Copy)]
+pub struct HashEntry {
+    hash_hi: u16,            // 2 bytes (~3 low bytes are encoded in the HashTable idx)
+    pub game_move: GameMove, // 8 bytes
+    score_val: i32,          // 2 bytes
+    depth_flags: u8,         // 1 byte
+    ply: u8,                 // 1 byte
+}
+
+const ALPHA_FLAG: u8 = 0b10000000;
+const BETA_FLAG:  u8 = 0b01000000;
+const DEPTH_MASK: u8 = 0b00111111;
+
+impl HashEntry {
+    fn empty() -> Self {
+        Self::new(1, GameMove::null_move(), ScoreCutoff::Alpha(0), 0, 0)
+    }
+
+    pub fn new(hash: u64, game_move: GameMove, score: ScoreCutoff, depth: usize, ply: usize) -> Self {
+        let depth_flags: u8;
+        let score_val: i32;
+        match score {
+            ScoreCutoff::Alpha(s) => {
+                score_val = s;
+                depth_flags = ALPHA_FLAG | (depth as u8);
+            }
+            ScoreCutoff::Beta(s) => {
+                score_val = s;
+                depth_flags = BETA_FLAG | (depth as u8);
+            }
+            ScoreCutoff::Exact(s) => {
+                score_val = s;
+                depth_flags = depth as u8;
+            }
+        }
+        Self {
+            hash_hi: (hash >> 48) as u16,
+            game_move,
+            score_val,
+            depth_flags,
+            ply: ply as u8,
+        }
+    }
+
+    pub fn depth(&self) -> u8 {
+        self.depth_flags & DEPTH_MASK
+    }
+
+    pub fn score(&self) -> ScoreCutoff {
+        if (self.depth_flags & BETA_FLAG) != 0 {
+            return ScoreCutoff::Beta(self.score_val);
+        }
+        if (self.depth_flags & ALPHA_FLAG) != 0 {
+            return ScoreCutoff::Alpha(self.score_val);
+        }
+        return ScoreCutoff::Exact(self.score_val);
+    }
+
+    pub fn check_hash(&self, hash: u64) -> bool {
+        self.hash_hi == (hash >> 48) as u16
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum ScoreCutoff {
+    Alpha(i32),
+    Beta(i32),
+    Exact(i32),
+}


### PR DESCRIPTION
- your 32bit move representation
- null window search
- internal iterative deepening
- fix tinue-in-one in move ordering (my mistake)
- search TT move before scoring move list
- aspiration window (disabled because bad)
- smaller tuned more flexible transposition table