### PR TITLE
New stack repr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,12 +32,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "board-game-traits"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f0c0fc76324ee558f1c6239a069c3101d74286eedd7d9b1e307d47b4f039c23"
-
-[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,7 +580,6 @@ name = "topaz-tak"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "board-game-traits",
  "cfg-if",
  "colorful",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitintr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba5a5c4df8ac8673f22698f443ef1ce3853d7f22d5a15ebf66b9a7553b173dd"
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +586,7 @@ name = "topaz-tak"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bitintr",
  "cfg-if",
  "colorful",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,6 +595,7 @@ dependencies = [
  "getopts",
  "getrandom",
  "instant",
+ "lazy_static",
  "miniserde",
  "rand_core",
  "rand_xoshiro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ getopts = {version = "0.2.21", optional = true}
 telnet = {version = "0.2", optional = true}
 dotenv = {version = "0.15.0", optional = true}
 miniserde = "0.1.24"
+bitintr = "0.3.0"
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0"
 crossbeam-channel = "0.5"
 cfg-if = "1.0.0"
 instant = "0.1.12"
+lazy_static = "*"
 rand_core = {version = "0.6.3", optional = true}
 rand_xoshiro = {version = "0.6.0", optional = true}
 getrandom = {version = "*", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ random = ["rand_core", "rand_xoshiro", "getrandom"]
 
 [dependencies]
 anyhow = "1.0"
-board-game-traits = "0.3"
 crossbeam-channel = "0.5"
 cfg-if = "1.0.0"
 instant = "0.1.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 
 [features]
 default = ["random", "cli"]
-cli = ["termtree", "colorful", "getopts", "telnet", "dotenv"]
-random = ["rand_core", "rand_xoshiro", "getrandom"]
+cli = ["termtree", "colorful", "getopts", "telnet", "dotenv", "miniserde"]
+random = ["rand_core", "rand_xoshiro", "getrandom", "bitintr"]
 
 [dependencies]
 anyhow = "1.0"
@@ -24,8 +24,8 @@ colorful = {version = "0.2", optional = true}
 getopts = {version = "0.2.21", optional = true}
 telnet = {version = "0.2", optional = true}
 dotenv = {version = "0.15.0", optional = true}
-miniserde = "0.1.24"
-bitintr = "0.3.0"
+miniserde = {version = "0.1.24", optional = true}
+bitintr = {version = "0.3.0", optional = true}
 
 [profile.release]
 debug = true

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -2,7 +2,6 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use topaz_tak::board::find_placement_road;
 use topaz_tak::board::{Bitboard6, Board6};
 use topaz_tak::eval::{Evaluator, Weights6, LOSE_SCORE};
-use topaz_tak::search::root_minimax;
 use topaz_tak::{execute_moves_check_valid, generate_all_moves, perft, Color, GameMove, TakBoard};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
@@ -76,16 +75,6 @@ fn evaluate_positions<E: Evaluator<Game = Board6>>(positions: &[Board6], eval: &
         sum += eval.evaluate(pos, 1);
     }
     sum
-}
-
-fn small_minimax(_depth: u16) {
-    let tps = "2,1,1,1,1,2S/1,12,1,x,1C,11112/x,2,2,212,2C,11121/2,21122,x2,1,x/x3,1,1,x/x2,2,21,x,112S 1 34";
-    let mut board = Board6::try_from_tps(tps).unwrap();
-    let eval = Weights6::default();
-    let (mv, score) = root_minimax(&mut board, &eval, 2);
-    assert!(score != LOSE_SCORE);
-    let only_move = GameMove::try_from_ptn("c5-", &board);
-    assert_eq!(mv, only_move);
 }
 
 fn placement_road(_x: ()) {

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use topaz_tak::board::find_placement_road;
 use topaz_tak::board::{Bitboard6, Board6};
-use topaz_tak::eval::{Evaluator, Evaluator6, LOSE_SCORE};
+use topaz_tak::eval::{Evaluator, Weights6, LOSE_SCORE};
 use topaz_tak::search::root_minimax;
 use topaz_tak::{execute_moves_check_valid, generate_all_moves, perft, Color, GameMove, TakBoard};
 
@@ -9,17 +9,21 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     // c.bench_function("small perft", |b| {
     //     b.iter(|| execute_small_perft(black_box(2)))
     // });
-    let mut pos = get_positions();
-    let mut legal = vec![Vec::new(); pos.len()];
-    for (board, moves) in pos.iter().zip(legal.iter_mut()) {
-        generate_all_moves(board, moves)
-    }
+    let pos = get_positions();
+    let eval = Weights6::default();
+    c.bench_function("eval", |b| {
+        b.iter(|| black_box(evaluate_positions(&pos, &eval)))
+    });
+    // let mut legal = vec![Vec::new(); pos.len()];
+    // for (board, moves) in pos.iter().zip(legal.iter_mut()) {
+    //     generate_all_moves(board, moves)
+    // }
     // let pos = get_positions();
     // let eval = Evaluator6 {};
     // c.bench_function("tak_threat", |b| {
     //     b.iter(|| check_for_tak(black_box(&mut pos), black_box(&mut legal)))
     // });
-    c.bench_function("captives", |b| b.iter(|| captives_count(black_box(&pos))));
+    // c.bench_function("captives", |b| b.iter(|| captives_count(black_box(&pos))));
 }
 
 fn execute_small_perft(depth: usize) {
@@ -77,7 +81,7 @@ fn evaluate_positions<E: Evaluator<Game = Board6>>(positions: &[Board6], eval: &
 fn small_minimax(_depth: u16) {
     let tps = "2,1,1,1,1,2S/1,12,1,x,1C,11112/x,2,2,212,2C,11121/2,21122,x2,1,x/x3,1,1,x/x2,2,21,x,112S 1 34";
     let mut board = Board6::try_from_tps(tps).unwrap();
-    let eval = Evaluator6 {};
+    let eval = Weights6::default();
     let (mv, score) = root_minimax(&mut board, &eval, 2);
     assert!(score != LOSE_SCORE);
     let only_move = GameMove::try_from_ptn("c5-", &board);

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -9,20 +9,20 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     // c.bench_function("small perft", |b| {
     //     b.iter(|| execute_small_perft(black_box(2)))
     // });
-    let pos = get_positions();
+    let mut pos = get_positions();
     let eval = Weights6::default();
-    c.bench_function("eval", |b| {
-        b.iter(|| black_box(evaluate_positions(&pos, &eval)))
-    });
-    // let mut legal = vec![Vec::new(); pos.len()];
-    // for (board, moves) in pos.iter().zip(legal.iter_mut()) {
-    //     generate_all_moves(board, moves)
-    // }
+    // c.bench_function("eval", |b| {
+    //     b.iter(|| black_box(evaluate_positions(&pos, &eval)))
+    // });
+    let mut legal = vec![Vec::new(); pos.len()];
+    for (board, moves) in pos.iter().zip(legal.iter_mut()) {
+        generate_all_moves(board, moves)
+    }
     // let pos = get_positions();
     // let eval = Evaluator6 {};
-    // c.bench_function("tak_threat", |b| {
-    //     b.iter(|| check_for_tak(black_box(&mut pos), black_box(&mut legal)))
-    // });
+    c.bench_function("tak_threat", |b| {
+        b.iter(|| check_for_tak(black_box(&mut pos), black_box(&mut legal)))
+    });
     // c.bench_function("captives", |b| b.iter(|| captives_count(black_box(&pos))));
 }
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -16,9 +16,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     }
     // let pos = get_positions();
     // let eval = Evaluator6 {};
-    c.bench_function("tak_threat", |b| {
-        b.iter(|| check_for_tak(black_box(&mut pos), black_box(&mut legal)))
-    });
+    // c.bench_function("tak_threat", |b| {
+    //     b.iter(|| check_for_tak(black_box(&mut pos), black_box(&mut legal)))
+    // });
+    c.bench_function("captives", |b| b.iter(|| captives_count(black_box(&pos))));
 }
 
 fn execute_small_perft(depth: usize) {
@@ -34,6 +35,17 @@ fn execute_small_perft(depth: usize) {
         .collect();
     // assert_eq!(&p_res[..], &[1, 190, 20698]);
     assert_eq!(&p_res[..], &[1, 190, 20698]);
+}
+
+fn captives_count(boards: &[Board6]) -> i32 {
+    let mut sum = 0;
+    for board in boards {
+        sum += board
+            .active_stacks(Color::White)
+            .map(|idx| board.board[idx].captive_friendly().0)
+            .sum::<i32>();
+    }
+    sum
 }
 
 fn check_for_tak(boards: &mut [Board6], legal_moves: &[Vec<GameMove>]) {

--- a/src/board.rs
+++ b/src/board.rs
@@ -1,8 +1,7 @@
 use crate::move_gen::{generate_all_moves, generate_all_stack_moves};
-use crate::{GameMove, Position, RevGameMove};
+use crate::{Color, GameMove, GameResult, Position, RevGameMove};
 use anyhow::{anyhow, bail, ensure, Result};
 pub use bitboard::*;
-use board_game_traits::{Color, GameResult};
 use std::fmt;
 
 mod bitboard;

--- a/src/board.rs
+++ b/src/board.rs
@@ -251,9 +251,26 @@ macro_rules! board_impl {
                         }
                     }
                 }
-                for m in storage.iter().copied() {
-                    if self.road_stack_throw(road_pieces, m) {
-                        return Some(m);
+                let cs = road_pieces.critical_squares();
+                if cs.pop_count() == 0 {
+                    // We don't need to look at stack moves that only have one friendly
+                    // Todo don't even generate these moves
+                    // Todo in wall stacks don't include top piece?
+                    for m in storage.iter().copied() {
+                        let (_, friendly) = self.board[m.src_index()].captive_friendly();
+                        if friendly == 0 {
+                            continue;
+                        }
+                        if self.road_stack_throw(road_pieces, m) {
+                            return Some(m);
+                        }
+                    }
+                } else {
+                    // Todo single friendly tiles need to be orthogonal to a cs
+                    for m in storage.iter().copied() {
+                        if self.road_stack_throw(road_pieces, m) {
+                            return Some(m);
+                        }
                     }
                 }
                 None

--- a/src/board/bitboard.rs
+++ b/src/board/bitboard.rs
@@ -184,6 +184,7 @@ pub trait Bitboard:
     fn lowest_index(self) -> usize;
     /// Converts a provided [TakBoard] square index into a single set bit in a bitboard
     fn index_to_bit(index: usize) -> Self;
+    fn raw_bits(self) -> u64;
     fn north(self) -> Self;
     fn east(self) -> Self;
     fn south(self) -> Self;
@@ -557,6 +558,9 @@ macro_rules! bitboard_impl {
             }
             fn pop_count(self) -> u32 {
                 (self.0).count_ones()
+            }
+            fn raw_bits(self) -> u64 {
+                self.0
             }
             fn north(self) -> Self {
                 Self::new(self.0 >> 8)

--- a/src/board/bitboard.rs
+++ b/src/board/bitboard.rs
@@ -85,7 +85,7 @@ where
         let mut storage = Self::default();
         storage.set_zobrist(TABLE.color_hash(Color::White));
         for (idx, stack) in board.iter().enumerate() {
-            if let Some(piece) = stack.last() {
+            if let Some(piece) = stack.top() {
                 let bit_pattern = T::index_to_bit(idx);
                 match piece {
                     Piece::WhiteFlat => {

--- a/src/board/bitboard.rs
+++ b/src/board/bitboard.rs
@@ -1,6 +1,6 @@
 use super::{Piece, Stack};
 use crate::board::zobrist::TABLE;
-use board_game_traits::Color;
+use crate::Color;
 use crate::TakBoard;
 
 #[derive(Default, PartialEq, Clone)]

--- a/src/board/bitboard.rs
+++ b/src/board/bitboard.rs
@@ -191,6 +191,7 @@ pub trait Bitboard:
     /// Converts a provided [TakBoard] square index into a single set bit in a bitboard
     fn index_to_bit(index: usize) -> Self;
     fn raw_bits(self) -> u64;
+    fn from_raw(val: u64) -> Self; 
     fn north(self) -> Self;
     fn east(self) -> Self;
     fn south(self) -> Self;
@@ -583,6 +584,9 @@ macro_rules! bitboard_impl {
             }
             fn raw_bits(self) -> u64 {
                 self.0
+            }
+            fn from_raw(val: u64) -> Self {
+                Self::new(val)
             }
             fn north(self) -> Self {
                 Self::new(self.0 >> 8)

--- a/src/board/piece.rs
+++ b/src/board/piece.rs
@@ -28,6 +28,12 @@ impl Piece {
             Piece::BlackFlat | Piece::BlackWall | Piece::BlackCap => Color::Black,
         }
     }
+    pub fn is_flat(self) -> bool {
+        match self {
+            Piece::WhiteFlat | Piece::BlackFlat => true,
+            _ => false,
+        }
+    }
     pub fn is_wall(self) -> bool {
         match self {
             Piece::WhiteWall | Piece::BlackWall => true,

--- a/src/board/piece.rs
+++ b/src/board/piece.rs
@@ -1,4 +1,4 @@
-use board_game_traits::Color;
+use crate::Color;
 
 #[derive(PartialEq, Clone, Copy)]
 pub enum Piece {

--- a/src/board/stack.rs
+++ b/src/board/stack.rs
@@ -102,6 +102,8 @@ impl Stack {
                 self.top_piece = Piece::BlackFlat;
             }
             bits.zobrist_middle(piece, self.index as usize, self.len());
+        } else {
+            self.top_piece = Piece::BlackFlat;
         }
         self.hash_in_top(bits);
         ret

--- a/src/board/stack.rs
+++ b/src/board/stack.rs
@@ -32,6 +32,9 @@ impl Stack {
             Piece::BlackFlat
         }
     }
+    pub fn bottom(&self) -> Option<Piece> {
+        self.from_top(self.length.wrapping_sub(1) as usize)
+    }
     /// Indexes the stack from the top, assuming the highest piece in the stack has index 0
     pub fn from_top(&self, index: usize) -> Option<Piece> {
         if index >= self.len() {

--- a/src/board/stack.rs
+++ b/src/board/stack.rs
@@ -45,6 +45,12 @@ impl Stack {
             Some(self.get_inner_piece(index))
         }
     }
+    pub fn has_wall(&self) -> bool {
+        self.top_piece.is_wall()
+    }
+    pub fn has_cap(&self) -> bool {
+        self.top_piece.is_cap()
+    }
     pub fn push<T: Bitboard>(&mut self, item: Piece, bits: &mut BitboardStorage<T>) {
         self.hash_out_top(bits);
         bits.zobrist_middle(item, self.index as usize, self.len());

--- a/src/board/stack.rs
+++ b/src/board/stack.rs
@@ -3,203 +3,424 @@ use super::Piece;
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct Stack {
-    data: Vec<Piece>,
-    index: usize,
+    data: u64,
+    length: u8,
+    index: u8,
+    top_piece: Piece,
 }
 
 impl Stack {
     pub const fn new() -> Self {
-        const VEC: Vec<Piece> = Vec::new();
-        const IDX: usize = 0;
         Stack {
-            data: VEC,
-            index: IDX,
+            data: 0,
+            length: 0,
+            index: 0,
+            top_piece: Piece::WhiteFlat,
         }
     }
     pub(crate) fn set_index(&mut self, index: usize) {
-        self.index = index;
+        self.index = index as u8;
     }
     pub fn init(&mut self, index: usize) {
-        self.data.reserve(8);
-        self.index = index;
+        self.index = index as u8;
+    }
+    fn get_inner_piece(&self, index: usize) -> Piece {
+        let mask = 1 << index;
+        if self.data & mask == 0 {
+            Piece::WhiteFlat
+        } else {
+            Piece::BlackFlat
+        }
     }
     /// Indexes the stack from the top, assuming the highest piece in the stack has index 0
     pub fn from_top(&self, index: usize) -> Option<Piece> {
-        if index >= self.data.len() {
-            return None;
+        if index >= self.len() {
+            None
+        } else if index == self.len() - 1 {
+            Some(self.top_piece)
+        } else {
+            Some(self.get_inner_piece(self.len() - 1 - index))
         }
-        Some(self.data[self.data.len() - 1 - index])
     }
     pub fn push<T: Bitboard>(&mut self, item: Piece, bits: &mut BitboardStorage<T>) {
         self.hash_out_top(bits);
-        bits.zobrist_middle(item, self.index, self.len());
-        self.data.push(item);
+        bits.zobrist_middle(item, self.index as usize, self.len());
+        self.length += 1;
+        let color_bit = (item.owner() == crate::Color::Black) as u64;
+        self.data = (self.data << 1) | color_bit;
+        self.top_piece = item;
         self.hash_in_top(bits);
     }
-    pub fn last(&self) -> Option<&Piece> {
-        self.data.last()
+    pub fn top(&self) -> Option<Piece> {
+        if self.length > 0 {
+            Some(self.top_piece)
+        } else {
+            None
+        }
     }
+    pub fn under_top(&self) -> Option<Piece> {
+        if self.length > 1 {
+            if self.data & 0b0010 == 0 {
+                Some(Piece::WhiteFlat)
+            } else {
+                Some(Piece::BlackFlat)
+            }
+        } else {
+            None
+        }
+    }
+    pub fn captive_friendly(&self) -> (i32, i32) {
+        if self.length <= 1 {
+            return (0, 0);
+        }
+        let black = (self.data >> 1).count_ones() as i32;
+        let white = self.length as i32 - 1 - black;
+        if self.top_piece.owner() == crate::Color::White {
+            (black, white)
+        } else {
+            (white, black)
+        }
+    }
+    // pub fn last(&self) -> Option<&Piece> {
+    //     self.data.last()
+    // }
     pub fn pop<T: Bitboard>(&mut self, bits: &mut BitboardStorage<T>) -> Option<Piece> {
         self.hash_out_top(bits);
-        let ret = self.data.pop();
+        let ret = self.top();
         if let Some(piece) = ret {
-            bits.zobrist_middle(piece, self.index, self.len());
+            self.data = self.data >> 1;
+            self.length -= 1;
+            if self.data & 1 == 0 {
+                self.top_piece = Piece::WhiteFlat;
+            } else {
+                self.top_piece = Piece::BlackFlat;
+            }
+            bits.zobrist_middle(piece, self.index as usize, self.len());
         }
         self.hash_in_top(bits);
         ret
     }
-    pub fn iter(&self) -> std::slice::Iter<Piece> {
-        self.data.iter()
+    pub fn iter(&self) -> StackIterator {
+        StackIterator::new(&self, 0)
     }
     pub fn len(&self) -> usize {
-        self.data.len()
+        self.length as usize
     }
     pub fn is_empty(&self) -> bool {
-        self.data.is_empty()
+        self.length == 0
     }
-    /// Mimicking the Extend trait from std, but we need an extra parameter
-    pub fn extend<T, U>(&mut self, iter: T, bits: &mut BitboardStorage<U>)
-    where
-        T: IntoIterator<Item = Piece>,
-        U: Bitboard,
-    {
-        for item in iter {
-            self.push(item, bits);
-        }
-    }
-    pub fn try_crush_wall<T: Bitboard>(&mut self) -> bool {
-        if self.len() >= 2 {
-            let wall_idx = self.len() - 2;
-            if let Some(crushed) = self.data[wall_idx].crush() {
-                self.data[wall_idx] = crushed;
-                return true;
+    pub fn add_stack<T: Bitboard>(
+        &mut self,
+        num: usize,
+        other: &mut Pickup,
+        bits: &mut BitboardStorage<T>,
+    ) {
+        self.hash_out_top(bits);
+        let add = other.take(num as u8);
+        // dbg!(format!("{:X}", add));
+        self.data = self.data << num;
+        self.data |= add;
+        if other.length == 0 {
+            self.top_piece = other.top;
+        } else {
+            if self.data & 1 == 0 {
+                self.top_piece = Piece::WhiteFlat;
+            } else {
+                self.top_piece = Piece::BlackFlat;
             }
         }
-        false
+        self.length += num as u8;
+        self.hash_in_many(num, bits);
     }
-    pub fn uncrush_wall<T: Bitboard>(&mut self) {
-        if self.len() >= 2 {
-            let wall_idx = self.len() - 2;
-            if let Some(uncrushed) = self.data[wall_idx].uncrush() {
-                self.data[wall_idx] = uncrushed;
-                return;
-            }
-        }
-        panic!("Could not find piece to uncrush!");
+    // /// Mimicking the Extend trait from std, but we need an extra parameter
+    // pub fn extend<T, U>(&mut self, iter: T, bits: &mut BitboardStorage<U>)
+    // where
+    //     T: IntoIterator<Item = Piece>,
+    //     U: Bitboard,
+    // {
+    //     for item in iter {
+    //         self.push(item, bits);
+    //     }
+    // }
+    // pub fn try_crush_wall<T: Bitboard>(&mut self) -> bool {
+    //     if self.len() >= 2 {
+    //         let wall_idx = self.len() - 2;
+    //         if let Some(crushed) = self.data[wall_idx].crush() {
+    //             self.data[wall_idx] = crushed;
+    //             return true;
+    //         }
+    //     }
+    //     false
+    // }
+    pub fn uncrush_top<T: Bitboard>(&mut self, bits: &mut BitboardStorage<T>) {
+        self.hash_out_top(bits);
+        self.top_piece = self.top_piece.uncrush().unwrap();
+        self.hash_in_top(bits);
     }
-    pub fn reverse_top<T: Bitboard>(&mut self, top_n: usize, bits: &mut BitboardStorage<T>) {
-        // If top_n is only 1 then we just reverse the first piece, which does nothing
-        if top_n > 1 {
-            self.hash_out_many(top_n, bits);
-            let range_st = self.len() - top_n;
-            let slice = &mut self.data[range_st..];
-            slice.reverse();
-            self.hash_in_many(top_n, bits);
-        }
-    }
+    // pub fn uncrush_wall<T: Bitboard>(&mut self) {
+    //     if self.len() >= 2 {
+    //         let wall_idx = self.len() - 2;
+    //         if let Some(uncrushed) = self.data[wall_idx].uncrush() {
+    //             self.data[wall_idx] = uncrushed;
+    //             return;
+    //         }
+    //     }
+    //     panic!("Could not find piece to uncrush!");
+    // }
+    // pub fn reverse_top<T: Bitboard>(&mut self, top_n: usize, bits: &mut BitboardStorage<T>) {
+    //     // If top_n is only 1 then we just reverse the first piece, which does nothing
+    //     if top_n > 1 {
+    //         self.hash_out_many(top_n, bits);
+    //         let range_st = self.len() - top_n;
+    //         let slice = &mut self.data[range_st..];
+    //         slice.reverse();
+    //         self.hash_in_many(top_n, bits);
+    //     }
+    // }
     pub fn split_off<T: Bitboard>(
         &mut self,
         top_n: usize,
         bits: &mut BitboardStorage<T>,
-    ) -> Vec<Piece> {
+    ) -> Pickup {
         self.hash_out_many(top_n, bits);
-        let split_idx = self.len() - top_n;
-        let vec = self.data.split_off(split_idx);
+        let mask = (1 << top_n) - 1;
+        let take_bits = self.data & mask;
+        let pickup = Pickup::new(take_bits as u8, self.top_piece, top_n as u8);
+        self.data = self.data >> top_n;
+        if self.data & 1 == 0 {
+            self.top_piece = Piece::WhiteFlat;
+        } else {
+            self.top_piece = Piece::BlackFlat;
+        }
+        self.length = self.length - top_n as u8;
         self.hash_in_top(bits);
-        vec
+        pickup
     }
     fn hash_out_many<T: Bitboard>(&self, top_n: usize, bits: &mut BitboardStorage<T>) {
-        if self.len() == 0 {
+        if self.length == 0 {
             return;
         }
+        let tile_index = self.index as usize;
         self.hash_out_top(bits);
-        for i in self.len() - top_n..self.len() {
-            let piece = self.data[i];
-            bits.zobrist_middle(piece, self.index, i);
+        let mut stack_bits = self.data;
+        for i in (self.len() - top_n..self.len()).rev() {
+            let piece = if stack_bits & 1 == 0 {
+                Piece::WhiteFlat
+            } else {
+                Piece::BlackFlat
+            };
+            bits.zobrist_middle(piece, tile_index, i);
+            stack_bits = stack_bits >> 1;
         }
         // Todo zobrist operations
     }
     fn hash_in_many<T: Bitboard>(&self, top_n: usize, bits: &mut BitboardStorage<T>) {
-        if self.len() == 0 {
+        if self.length == 0 {
             return;
         }
+        let tile_index = self.index as usize;
         self.hash_in_top(bits);
-        for i in self.len() - top_n..self.len() {
-            let piece = self.data[i];
-            bits.zobrist_middle(piece, self.index, i);
+        // Todo off by one ?
+        let mut stack_bits = self.data;
+        for i in (self.len() - top_n..self.len()).rev() {
+            let piece = if stack_bits & 1 == 0 {
+                Piece::WhiteFlat
+            } else {
+                Piece::BlackFlat
+            };
+            bits.zobrist_middle(piece, tile_index, i);
+            stack_bits = stack_bits >> 1;
         }
         // Todo zobrist operations
     }
     fn hash_in_top<T: Bitboard>(&self, bits: &mut BitboardStorage<T>) {
-        let bitboard = T::index_to_bit(self.index);
-        match self.data.last() {
+        let index = self.index as usize;
+        let bitboard = T::index_to_bit(index);
+        match self.top() {
             Some(Piece::WhiteFlat) => {
                 bits.white |= bitboard;
                 bits.flat |= bitboard;
-                bits.zobrist_top(Piece::WhiteFlat, self.index);
+                bits.zobrist_top(Piece::WhiteFlat, index);
             }
             Some(Piece::BlackFlat) => {
                 bits.black |= bitboard;
                 bits.flat |= bitboard;
-                bits.zobrist_top(Piece::BlackFlat, self.index);
+                bits.zobrist_top(Piece::BlackFlat, index);
             }
             Some(Piece::WhiteWall) => {
                 bits.white |= bitboard;
                 bits.wall |= bitboard;
-                bits.zobrist_top(Piece::WhiteWall, self.index);
+                bits.zobrist_top(Piece::WhiteWall, index);
             }
             Some(Piece::BlackWall) => {
                 bits.black |= bitboard;
                 bits.wall |= bitboard;
-                bits.zobrist_top(Piece::BlackWall, self.index);
+                bits.zobrist_top(Piece::BlackWall, index);
             }
             Some(Piece::WhiteCap) => {
                 bits.white |= bitboard;
                 bits.cap |= bitboard;
-                bits.zobrist_top(Piece::WhiteCap, self.index);
+                bits.zobrist_top(Piece::WhiteCap, index);
             }
             Some(Piece::BlackCap) => {
                 bits.black |= bitboard;
                 bits.cap |= bitboard;
-                bits.zobrist_top(Piece::BlackCap, self.index);
+                bits.zobrist_top(Piece::BlackCap, index);
             }
             _ => {}
         }
     }
     fn hash_out_top<T: Bitboard>(&self, bits: &mut BitboardStorage<T>) {
-        let bitboard = T::index_to_bit(self.index);
-        match self.data.last() {
+        let index = self.index as usize;
+        let bitboard = T::index_to_bit(index);
+        match self.top() {
             Some(Piece::WhiteFlat) => {
                 bits.white -= bitboard;
                 bits.flat -= bitboard;
-                bits.zobrist_top(Piece::WhiteFlat, self.index);
+                bits.zobrist_top(Piece::WhiteFlat, index);
             }
             Some(Piece::BlackFlat) => {
                 bits.black -= bitboard;
                 bits.flat -= bitboard;
-                bits.zobrist_top(Piece::BlackFlat, self.index);
+                bits.zobrist_top(Piece::BlackFlat, index);
             }
             Some(Piece::WhiteWall) => {
                 bits.white -= bitboard;
                 bits.wall -= bitboard;
-                bits.zobrist_top(Piece::WhiteWall, self.index);
+                bits.zobrist_top(Piece::WhiteWall, index);
             }
             Some(Piece::BlackWall) => {
                 bits.black -= bitboard;
                 bits.wall -= bitboard;
-                bits.zobrist_top(Piece::BlackWall, self.index);
+                bits.zobrist_top(Piece::BlackWall, index);
             }
             Some(Piece::WhiteCap) => {
                 bits.white -= bitboard;
                 bits.cap -= bitboard;
-                bits.zobrist_top(Piece::WhiteCap, self.index);
+                bits.zobrist_top(Piece::WhiteCap, index);
             }
             Some(Piece::BlackCap) => {
                 bits.black -= bitboard;
                 bits.cap -= bitboard;
-                bits.zobrist_top(Piece::BlackCap, self.index);
+                bits.zobrist_top(Piece::BlackCap, index);
             }
             _ => {}
+        }
+    }
+}
+
+pub struct StackIterator<'a> {
+    stack: &'a Stack,
+    count: usize,
+}
+
+impl<'a> StackIterator<'a> {
+    fn new(stack: &'a Stack, count: usize) -> Self {
+        Self { stack, count }
+    }
+}
+
+impl<'a> Iterator for StackIterator<'a> {
+    type Item = Piece;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.count += 1;
+        if self.count > self.stack.len() {
+            return None;
+        } else if self.count == self.stack.len() {
+            return Some(self.stack.top_piece);
+        }
+        let mask = 1 << (self.stack.len() - self.count);
+        if self.stack.data & mask == 0 {
+            Some(Piece::WhiteFlat)
+        } else {
+            Some(Piece::BlackFlat)
+        }
+    }
+}
+
+impl From<Vec<Piece>> for Stack {
+    fn from(vec: Vec<Piece>) -> Self {
+        let length = vec.len();
+        if length == 0 {
+            Stack::new()
+        } else {
+            let top_piece = *vec.last().unwrap();
+            let mut data = 0;
+            for piece in vec.into_iter().rev() {
+                if piece.owner() == crate::Color::Black {
+                    data &= 1;
+                }
+                data << 1;
+            }
+            Stack {
+                data,
+                length: length as u8,
+                top_piece,
+                index: 0,
+            }
+        }
+    }
+}
+
+pub struct Pickup {
+    pieces: u8,
+    top: Piece,
+    length: u8,
+}
+
+impl Pickup {
+    pub fn new(pieces: u8, top: Piece, length: u8) -> Self {
+        // Magic reverse bits of byte
+        // https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith64Bits
+        // let mut bits = (((pieces as u64).wrapping_mul(0x80200802u64)) & 0x0884422110u64)
+        //     .wrapping_mul(0x0101010101u64)
+        //     >> 32;
+        // bits = bits >> (8 - length);
+        Self {
+            pieces,
+            top,
+            length,
+        }
+    }
+    fn take(&mut self, count: u8) -> u64 {
+        // dbg!(count);
+        // dbg!(self.length);
+        let keep = self.length - count;
+        let keep_mask: u64 = (1 << keep) - 1;
+        let out = self.pieces >> keep;
+        self.length -= count;
+        self.pieces = self.pieces & (keep_mask as u8);
+        out as u64
+    }
+    pub fn append(&mut self, other: Self) {
+        self.top = other.top;
+        self.pieces = self.pieces << other.length;
+        self.pieces |= other.pieces;
+        self.length += other.length;
+    }
+}
+
+impl Default for Pickup {
+    fn default() -> Self {
+        Self {
+            pieces: 0,
+            top: Piece::WhiteFlat,
+            length: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    pub fn bits_reverse() {
+        let pats = [0b1001_1011, 0b1110_0001, 0b0011_0000];
+        let ans = [0b1101_1001, 0b1000_0111, 0b0000_1100];
+        for (pat, ans) in pats.iter().zip(ans.iter()) {
+            let pickup = Pickup::new(*pat, Piece::BlackCap, 8);
+            assert_eq!(pickup.pieces, *ans);
         }
     }
 }

--- a/src/board/zobrist.rs
+++ b/src/board/zobrist.rs
@@ -51,10 +51,10 @@ impl ZobristTable {
         let mut hash = 0;
         for (sq, stack) in board.board().iter().enumerate() {
             for (stack_pos, piece) in stack.iter().enumerate() {
-                hash ^= self.stack_hash(*piece, sq, stack_pos);
+                hash ^= self.stack_hash(piece, sq, stack_pos);
             }
-            if let Some(piece) = stack.last() {
-                hash ^= self.top_hash(*piece, sq);
+            if let Some(piece) = stack.top() {
+                hash ^= self.top_hash(piece, sq);
             }
         }
         hash ^= self.color_hash(board.active_player());
@@ -126,6 +126,23 @@ mod test {
             board.reverse_move(rev);
             assert_eq!(board.bits.zobrist(), init_zobrist);
         }
+    }
+    #[test]
+    pub fn consistent_hash() {
+        // Used for checking that zobrist hashes are as expected for move gen and do_move purposes
+        // This function must be changed if the zobrist keys themselves are updated
+        let tps = "1,1,1,1,1,2/x,1,1,2,2,2/1,1,112S,2S,2S,1/1,2,2,2,21221,21/21,2,2,21,x,12/12,12C,x,221,2222221C,x 1 39";
+        let mut board = Board6::try_from_tps(tps).unwrap();
+        let mut buffer = Vec::new();
+        generate_all_moves(&board, &mut buffer);
+        assert_eq!(buffer.len(), 174);
+        let mut hash = 0;
+        for mv in buffer {
+            let rev = board.do_move(mv);
+            hash ^= board.hash();
+            board.reverse_move(rev);
+        }
+        assert_eq!(hash, 9736573932680568458);
     }
     // #[test]
     // pub fn dummy() {

--- a/src/board/zobrist.rs
+++ b/src/board/zobrist.rs
@@ -1,7 +1,5 @@
 use crate::board::Board7;
-use crate::Piece;
-use crate::TakBoard;
-use board_game_traits::Color;
+use crate::{Color, Piece, TakBoard};
 // use rand_core::{RngCore, SeedableRng};
 // use rand_xoshiro::Xoshiro256PlusPlus;
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2,8 +2,8 @@ use super::{Bitboard, Piece, Stack};
 use crate::board::BitIndexIterator;
 use crate::board::TakBoard;
 use crate::board::{Board5, Board6};
+use crate::Color;
 use crate::Position;
-use board_game_traits::Color;
 
 pub trait Evaluator {
     type Game: TakBoard;

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -278,6 +278,7 @@ impl<B> BitOutcome<B> {
 /// A method that finds the most complete road among orthogonally connected components.
 /// It allows one non-blocking piece to be overwritten for free, leading to decreased
 /// concern for blockades, and extending roads that seem unlikely to ever be finished
+#[cfg(test)]
 fn one_gap_road_old<B: Bitboard + std::fmt::Debug>(road_bits: B, blocker_bits: B) -> (i32, usize) {
     let mut iter = ComponentIterator::new(road_bits);
     let mut best = 0;
@@ -365,6 +366,7 @@ fn flat_placement_road_h<B: Bitboard + std::fmt::Debug>(road_bits: B, empty: B) 
 /// the original version, but the road play still seems uninspired, extending threats
 /// that seem unlikely to be finished, while ignoring future threats simply because
 /// they haven't yet reached fruition.
+#[cfg(test)]
 fn one_gap_road<B: Bitboard + std::fmt::Debug>(road_bits: B) -> (i32, usize) {
     let mut iter = ComponentIterator::new(road_bits);
     let mut best = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 use anyhow::{anyhow, ensure, Result};
 pub use board::{Bitboard, BitboardStorage, Piece, Stack, TakBoard};
 // pub use board_game_traits::{Color, GameResult};
-pub use move_gen::{generate_all_moves, GameMove, RevGameMove};
+pub use move_gen::{generate_all_moves, magic::generate_move_magic6, GameMove, RevGameMove};
 
 pub mod board;
 pub mod eval;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,11 @@
 use anyhow::{anyhow, ensure, Result};
 pub use board::{Bitboard, BitboardStorage, Piece, Stack, TakBoard};
 // pub use board_game_traits::{Color, GameResult};
-pub use move_gen::{generate_all_moves, magic::generate_move_magic6, GameMove, RevGameMove};
+pub use move_gen::{generate_all_moves, GameMove, RevGameMove};
 
 pub mod board;
 pub mod eval;
-mod move_gen;
+pub mod move_gen;
 pub mod search;
 pub mod transposition_table;
 

--- a/src/move_gen.rs
+++ b/src/move_gen.rs
@@ -1,5 +1,5 @@
 use super::Piece;
-use crate::board::TakBoard;
+use crate::board::{BitIndexIterator, TakBoard};
 use crate::Color;
 use crate::{Bitboard, BitboardStorage};
 use std::fmt;
@@ -86,7 +86,16 @@ pub fn generate_aggressive_place_moves<T: TakBoard>(board: &T, moves: &mut Vec<G
 /// Generates all legal sliding movements for the active player's stacks.
 pub fn generate_all_stack_moves<T: TakBoard, B: MoveBuffer>(board: &T, moves: &mut B) {
     let start_locs = board.active_stacks(board.side_to_move());
-    for index in start_locs {
+    generate_masked_stack_moves(board, moves, start_locs);
+}
+
+/// Generates all legal sliding movements for only the provided stacks
+pub fn generate_masked_stack_moves<T: TakBoard, B: MoveBuffer>(
+    board: &T,
+    moves: &mut B,
+    stacks: BitIndexIterator<T::Bits>,
+) {
+    for index in stacks {
         let stack_height = board.index(index).len();
         let start_move = GameMove(index as u32);
         let limits = find_move_limits(board, index);

--- a/src/move_gen.rs
+++ b/src/move_gen.rs
@@ -5,7 +5,7 @@ use crate::{Bitboard, BitboardStorage};
 use std::fmt;
 
 mod move_order;
-pub use move_order::{HistoryMoves, KillerMoves, SmartMoveBuffer};
+pub use move_order::{KillerMoves, PlaceHistory, SmartMoveBuffer};
 pub mod magic;
 pub mod ptn;
 

--- a/src/move_gen.rs
+++ b/src/move_gen.rs
@@ -522,9 +522,9 @@ fn find_dir_limit<F, T>(
     row = res.0;
     col = res.1;
     while let Some(stack) = board.try_tile(row, col) {
-        match stack.last() {
+        match stack.top() {
             Some(piece) if piece.is_blocker() => {
-                if board.tile(st_row, st_col).last().unwrap().is_cap() && piece.is_wall() {
+                if board.tile(st_row, st_col).top().unwrap().is_cap() && piece.is_wall() {
                     limits.can_crush[dir] = true;
                 }
                 break;

--- a/src/move_gen.rs
+++ b/src/move_gen.rs
@@ -6,6 +6,7 @@ use std::fmt;
 
 mod move_order;
 pub use move_order::{HistoryMoves, KillerMoves, SmartMoveBuffer};
+mod magic;
 pub mod ptn;
 
 pub trait MoveBuffer {

--- a/src/move_gen.rs
+++ b/src/move_gen.rs
@@ -7,7 +7,7 @@ use std::fmt;
 
 mod move_order;
 pub use move_order::{HistoryMoves, KillerMoves, SmartMoveBuffer};
-mod magic;
+pub mod magic;
 pub mod ptn;
 
 pub trait MoveBuffer {
@@ -370,14 +370,12 @@ impl MoveLimits {
 /// steps[dir] + 1 tile. If a fast bitwise method for wall detection is found,
 /// the empty board limits can be precomputed to replace this function.
 pub fn find_move_limits<T: TakBoard>(board: &T, st_index: usize) -> MoveLimits {
-    // let (st_row, st_col) = board.row_col(st_index);
     let mut limits = MoveLimits::new();
     let bits = board.bits();
     find_dir_limit(bits, st_index, 0, &mut limits, T::Bits::north);
     find_dir_limit(bits, st_index, 1, &mut limits, T::Bits::east);
     find_dir_limit(bits, st_index, 2, &mut limits, T::Bits::south);
     find_dir_limit(bits, st_index, 3, &mut limits, T::Bits::west);
-    // dbg!(&limits);
     limits
 }
 
@@ -395,43 +393,22 @@ fn find_dir_limit<B, F>(
 {
     let mut counter = 0;
     let st_bit = B::index_to_bit(st_idx);
-    // dbg!(st_bit.raw_bits());
     let cap_stack = (st_bit & board.cap) != B::ZERO;
     let mut bit = step_fn(st_bit);
-    // dbg!(bit.raw_bits());
     while bit != B::ZERO {
         if (bit & board.cap) != B::ZERO {
-            // dbg!(board.cap.raw_bits());
             break;
         } else if (bit & board.wall) != B::ZERO {
-            // dbg!(board.wall.raw_bits());
             if cap_stack {
                 limits.can_crush[dir] = true;
             }
             break;
         }
         bit = step_fn(bit);
-        // dbg!(bit.raw_bits());
         counter += 1;
     }
     limits.steps[dir] = counter;
 }
-
-// fn step_north(row: usize, col: usize) -> (usize, usize) {
-//     (row.wrapping_sub(1), col)
-// }
-
-// fn step_south(row: usize, col: usize) -> (usize, usize) {
-//     (row + 1, col)
-// }
-
-// fn step_east(row: usize, col: usize) -> (usize, usize) {
-//     (row, col + 1)
-// }
-
-// fn step_west(row: usize, col: usize) -> (usize, usize) {
-//     (row, col.wrapping_sub(1))
-// }
 
 /// Find all stack moves for a single stack in one direction. Calls the recursive
 /// function [recursive_stack_moves] 1..=pieces_available times.

--- a/src/move_gen.rs
+++ b/src/move_gen.rs
@@ -1,6 +1,6 @@
 use super::Piece;
 use crate::board::TakBoard;
-use board_game_traits::Color;
+use crate::Color;
 use miniserde::{de::Visitor, make_place, Deserialize, Serialize};
 use std::fmt;
 

--- a/src/move_gen/magic.rs
+++ b/src/move_gen/magic.rs
@@ -1,5 +1,4 @@
-use crate::{board::Bitboard6, Bitboard, BitboardStorage};
-use bitintr::Pdep;
+use crate::{board::Bitboard6, Bitboard, BitboardStorage, TakBoard};
 
 use super::{find_dir_limit, MoveLimits};
 
@@ -45,6 +44,46 @@ const ORTH_MASK6: [u64; 36] = [
     0x7e404040404000,
 ];
 
+// Masks for magic numbers
+const MOVE_MAGIC6: [u64; 36] = [
+    2207646891008,
+    4415293765632,
+    8830587515904,
+    17661175016448,
+    35322350017536,
+    70644700036096,
+    2207650676736,
+    4415297159168,
+    8830590386176,
+    17661176840192,
+    35322349748224,
+    70644699758592,
+    2208619954176,
+    4416166166528,
+    8831325700096,
+    17661644767232,
+    35322282901504,
+    70644632911872,
+    2456754978816,
+    4638632050688,
+    9019566063616,
+    17781434089472,
+    35305170141184,
+    70627520151552,
+    65979321286656,
+    61589898395648,
+    57209099124736,
+    48447500582912,
+    30924303499264,
+    66246653509632,
+    16890706249515008,
+    15767013989548032,
+    14645529376456704,
+    12402560150274048,
+    7916621697908736,
+    16959143302660096,
+];
+
 #[rustfmt::skip]
 // Number of bits necessary for the magic bitboard for a 6x6 Board
 const MAGIC_COUNT6: [usize; 36] = [
@@ -55,6 +94,82 @@ const MAGIC_COUNT6: [usize; 36] = [
     7, 6, 6, 6, 6, 7,
     8, 7, 7, 7, 7, 8,
 ];
+
+struct MagicMoveArray<const N: usize, const FULL: usize> {
+    storage: [MoveGenValue; FULL],
+    offsets: [Offset; N],
+}
+
+impl<const N: usize, const FULL: usize> MagicMoveArray<N, FULL> {
+    fn lookup<T: TakBoard>(&self, board: &T, idx: usize) -> MoveLimits {
+        let shift = 64 - MAGIC_COUNT6[idx];
+        let real_idx = self.offsets[idx].lookup(board.bits().wall.raw_bits(), shift);
+        todo!()
+    }
+}
+
+#[derive(Clone)]
+struct Offset {
+    offset: usize,
+    magic: u64,
+}
+
+impl Offset {
+    fn new(offset: usize, magic: u64) -> Self {
+        Self { offset, magic }
+    }
+    fn lookup(&self, key: u64, shift: usize) -> usize {
+        (self.magic.wrapping_mul(key) >> shift) as usize + self.offset
+    }
+}
+
+#[derive(Default)]
+struct Jagged2DBuilder<V> {
+    storage: Vec<Vec<V>>,
+    offsets: Vec<Offset>,
+}
+
+impl<V> Jagged2DBuilder<V> {
+    pub fn push(&mut self, magic: u64, data: Vec<V>) {
+        let offset = self.full_len();
+        self.storage.push(data);
+        self.offsets.push(Offset::new(offset, magic));
+    }
+    pub fn full_len(&self) -> usize {
+        self.offsets.last().map(|x| x.offset).unwrap_or(0)
+            + self.storage.last().map(|x| x.len()).unwrap_or(0)
+    }
+}
+
+pub fn get_move_limits<T: TakBoard>(board: &T, sq_idx: usize) -> MoveLimits {
+    todo!()
+}
+
+struct MoveGenValue {
+    steps: [u8; 4],
+    north: u8,
+    east: u8,
+    south: u8,
+    west: u8,
+}
+
+impl MoveGenValue {
+    fn get<T: TakBoard>(&self, board: &T, idx: usize) -> MoveLimits {
+        let capstone = board.board()[idx].has_cap();
+        if capstone {
+            let mut can_crush = [false, false, false, false];
+            // If the index would be off the board, index to the square itself
+            // The answer must be "no" because the piece in question is a capstone
+            can_crush[0] = board.board()[self.north as usize].has_wall();
+            can_crush[1] = board.board()[self.east as usize].has_wall();
+            can_crush[2] = board.board()[self.south as usize].has_wall();
+            can_crush[3] = board.board()[self.west as usize].has_wall();
+            MoveLimits::new(self.steps, can_crush)
+        } else {
+            MoveLimits::new(self.steps, [false, false, false, false])
+        }
+    }
+}
 
 #[derive(Clone, Default)]
 struct LookupTempKey {
@@ -78,6 +193,7 @@ impl LookupTempKey {
 
 #[cfg(feature = "random")]
 pub fn generate_move_magic6<R: rand_core::RngCore>(rng: &mut R) {
+    let mut builder = Jagged2DBuilder::default();
     for idx in 0..36 {
         let mut magic = 0;
         let bits: Vec<_> = get_iter6(idx).collect();
@@ -102,9 +218,13 @@ pub fn generate_move_magic6<R: rand_core::RngCore>(rng: &mut R) {
                 }
             }
         }
+        builder.push(magic, lookup);
         dbg!(magic);
-        // break; // Dummy break for testing
     }
+    let offsets: Vec<_> = builder.offsets.iter().cloned().map(|x| x.offset).collect();
+    // dbg!(&offsets[..]);
+    // dbg!(offsets.len());
+    // dbg!(builder.full_len());
 }
 
 #[cfg(feature = "random")]
@@ -113,21 +233,42 @@ fn gen_magic<R: rand_core::RngCore>(rng: &mut R) -> u64 {
 }
 
 /// Return an iterator over all possible relevant blocker configurations for a given square
+#[cfg(feature = "random")]
 fn get_iter6(idx: usize) -> impl Iterator<Item = u64> {
-    // Mask out the squares where blockers are irrelevant
-    let bad_mask = Bitboard6::index_to_bit(idx)
-        | Bitboard6::top()
-        | Bitboard6::bottom()
-        | Bitboard6::left()
-        | Bitboard6::right();
-    let orth_mask = ORTH_MASK6[idx] & !bad_mask.raw_bits();
+    use bitintr::Pdep;
+    let orth_mask = MOVE_MAGIC6[idx];
     let bits_needed = MAGIC_COUNT6[idx];
+    assert!(orth_mask.count_ones() == bits_needed as u32);
     let max = 1 << bits_needed;
     (0..max).map(move |x| x.pdep(orth_mask))
 }
 
+fn gen_mask6() -> Vec<u64> {
+    // Mask out the squares where blockers are irrelevant
+    let mut vec = Vec::new();
+    for idx in 0..36 {
+        let b = Bitboard6::index_to_bit(idx);
+        let f = |x: Bitboard6| {
+            if b & x == Bitboard6::ZERO {
+                x
+            } else {
+                Bitboard6::ZERO
+            }
+        };
+        let bad_mask = Bitboard6::index_to_bit(idx)
+            | f(Bitboard6::top())
+            | f(Bitboard6::bottom())
+            | f(Bitboard6::left())
+            | f(Bitboard6::right());
+        // Todo this is wrong!
+        let orth_mask = ORTH_MASK6[idx] & !bad_mask.raw_bits();
+        vec.push(orth_mask);
+    }
+    vec
+}
+
 fn move_limits<T: Bitboard>(bits: &BitboardStorage<T>, st_index: usize) -> MoveLimits {
-    let mut limits = MoveLimits::new();
+    let mut limits = MoveLimits::default();
     find_dir_limit(bits, st_index, 0, &mut limits, T::north);
     find_dir_limit(bits, st_index, 1, &mut limits, T::east);
     find_dir_limit(bits, st_index, 2, &mut limits, T::south);
@@ -151,9 +292,10 @@ mod test {
         assert_eq!(256, get_iter6(0).count());
         assert_eq!(64, get_iter6(7).count());
         let mut iter = get_iter6(7);
-        // while let Some(x) = iter.next() {
-        //     println!("{}", x);
-        // }
+        // dbg!(gen_mask6());
+        while let Some(x) = iter.next() {
+            println!("{}", x);
+        }
         // assert!(false);
     }
     fn generate_orth<B: Bitboard>() -> Vec<B> {

--- a/src/move_gen/magic.rs
+++ b/src/move_gen/magic.rs
@@ -5,7 +5,7 @@ use super::{find_dir_limit, MoveLimits};
 // const FILE_TABLE: [[u8; 4]; 6] = [[0u8; 4]; 6];
 
 // Bits which are orthogonal to the indexing square for a 6x6 Bitboard
-const ORTH_MASK6: [u64; 36] = [
+pub const ORTH_MASK6: [u64; 36] = [
     0x2020202027e00,
     0x4040404047e00,
     0x8080808087e00,
@@ -285,17 +285,18 @@ mod test {
         let vec = generate_orth::<Bitboard6>();
         assert_eq!(vec[0], Bitboard6::new(0x2020202027e00));
         assert_eq!(vec[15], Bitboard6::new(0x1010107e101000));
+        dbg!(&vec);
         assert!(ORTH_MASK6
             .iter()
             .zip(vec.into_iter())
             .all(|(x, y)| *x == y.raw_bits()));
         assert_eq!(256, get_iter6(0).count());
         assert_eq!(64, get_iter6(7).count());
-        let mut iter = get_iter6(7);
-        // dbg!(gen_mask6());
-        while let Some(x) = iter.next() {
-            println!("{}", x);
-        }
+        // let mut iter = get_iter6(7);
+        // // dbg!(gen_mask6());
+        // while let Some(x) = iter.next() {
+        //     println!("{}", x);
+        // }
         // assert!(false);
     }
     fn generate_orth<B: Bitboard>() -> Vec<B> {

--- a/src/move_gen/magic.rs
+++ b/src/move_gen/magic.rs
@@ -1,0 +1,133 @@
+use crate::{board::Bitboard6, Bitboard};
+use bitintr::Pdep;
+
+// const FILE_TABLE: [[u8; 4]; 6] = [[0u8; 4]; 6];
+
+// Bits which are orthogonal to the indexing square for a 6x6 Bitboard
+const ORTH_MASK6: [u64; 36] = [
+    0x2020202027e00,
+    0x4040404047e00,
+    0x8080808087e00,
+    0x10101010107e00,
+    0x20202020207e00,
+    0x40404040407e00,
+    0x20202027e0200,
+    0x40404047e0400,
+    0x80808087e0800,
+    0x101010107e1000,
+    0x202020207e2000,
+    0x404040407e4000,
+    0x202027e020200,
+    0x404047e040400,
+    0x808087e080800,
+    0x1010107e101000,
+    0x2020207e202000,
+    0x4040407e404000,
+    0x2027e02020200,
+    0x4047e04040400,
+    0x8087e08080800,
+    0x10107e10101000,
+    0x20207e20202000,
+    0x40407e40404000,
+    0x27e0202020200,
+    0x47e0404040400,
+    0x87e0808080800,
+    0x107e1010101000,
+    0x207e2020202000,
+    0x407e4040404000,
+    0x7e020202020200,
+    0x7e040404040400,
+    0x7e080808080800,
+    0x7e101010101000,
+    0x7e202020202000,
+    0x7e404040404000,
+];
+
+#[rustfmt::skip]
+// Number of bits necessary for the magic bitboard for a 6x6 Board
+const MAGIC_COUNT6: [usize; 36] = [
+    8, 7, 7, 7, 7, 8,
+    7, 6, 6, 6, 6, 7,
+    7, 6, 6, 6, 6, 7,
+    7, 6, 6, 6, 6, 7,
+    7, 6, 6, 6, 6, 7,
+    8, 7, 7, 7, 7, 8,
+];
+
+/// Return an iterator over all possible relevant blocker configurations for a given square
+fn get_iter6(idx: usize) -> impl Iterator<Item = u64> {
+    // Mask out the squares where blockers are irrelevant
+    let bad_mask = Bitboard6::index_to_bit(idx)
+        | Bitboard6::top()
+        | Bitboard6::bottom()
+        | Bitboard6::left()
+        | Bitboard6::right();
+    let orth_mask = ORTH_MASK6[idx] & !bad_mask.raw_bits();
+    let bits_needed = MAGIC_COUNT6[idx];
+    let max = 1 << bits_needed;
+    (0..max).map(move |x| x.pdep(orth_mask))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::board::Bitboard6;
+    #[test]
+    fn orth() {
+        let vec = generate_orth::<Bitboard6>();
+        assert_eq!(vec[0], Bitboard6::new(0x2020202027e00));
+        assert_eq!(vec[15], Bitboard6::new(0x1010107e101000));
+        assert!(ORTH_MASK6
+            .iter()
+            .zip(vec.into_iter())
+            .all(|(x, y)| *x == y.raw_bits()));
+        assert_eq!(256, get_iter6(0).count());
+        assert_eq!(64, get_iter6(7).count());
+        let mut iter = get_iter6(7);
+        // while let Some(x) = iter.next() {
+        //     println!("{}", x);
+        // }
+        // assert!(false);
+    }
+    fn generate_orth<B: Bitboard>() -> Vec<B> {
+        let mut table = vec![B::ZERO; B::size() * B::size()];
+
+        for idx in 0..table.len() {
+            let bit = B::index_to_bit(idx);
+            table[idx] = ray_north(bit) | ray_south(bit) | ray_east(bit) | ray_west(bit);
+        }
+        table
+    }
+    fn ray_north<B: Bitboard>(mut bits: B) -> B {
+        let mut last_bits = B::ZERO;
+        while bits != last_bits {
+            last_bits = bits;
+            bits = bits | bits.north();
+        }
+        bits
+    }
+    fn ray_south<B: Bitboard>(mut bits: B) -> B {
+        let mut last_bits = B::ZERO;
+        while bits != last_bits {
+            last_bits = bits;
+            bits = bits | bits.south();
+        }
+        bits
+    }
+    fn ray_east<B: Bitboard>(mut bits: B) -> B {
+        let mut last_bits = B::ZERO;
+        while bits != last_bits {
+            last_bits = bits;
+            bits = bits | bits.east();
+        }
+        bits
+    }
+    fn ray_west<B: Bitboard>(mut bits: B) -> B {
+        let mut last_bits = B::ZERO;
+        while bits != last_bits {
+            last_bits = bits;
+            bits = bits | bits.west();
+        }
+        bits
+    }
+}

--- a/src/move_gen/move_order.rs
+++ b/src/move_gen/move_order.rs
@@ -46,7 +46,7 @@ impl SmartMoveBuffer {
             for step in x.mv.quantity_iter(T::SIZE) {
                 debug_assert!(step.quantity > 0);
                 offset += step.quantity as usize;
-                let covered = board.index(step.index).last();
+                let covered = board.index(step.index).top();
                 let covering = stack_data[offset];
                 // println!("{}", &x.mv.to_ptn::<T>());
                 // if &x.mv.to_ptn::<T>() == DEBUG {
@@ -79,7 +79,7 @@ impl SmartMoveBuffer {
                     score -= 2;
                 }
             }
-            if let Some(piece) = src_stack.last() {
+            if let Some(piece) = src_stack.top() {
                 if piece.is_cap() {
                     score += 1;
                     if x.mv.crush() {

--- a/src/move_gen/ptn.rs
+++ b/src/move_gen/ptn.rs
@@ -106,7 +106,7 @@ impl GameMove {
                 };
                 tile_counter += 1;
             }
-            if let Some(p) = board.index(dest).last() {
+            if let Some(p) = board.index(dest).top() {
                 if p.is_wall() {
                     game_move = game_move.set_crush();
                 }

--- a/src/move_gen/ptn.rs
+++ b/src/move_gen/ptn.rs
@@ -1,4 +1,4 @@
-use board_game_traits::Color;
+use crate::Color;
 
 use super::{GameMove, Piece};
 use crate::board::TakBoard;

--- a/src/search.rs
+++ b/src/search.rs
@@ -13,6 +13,7 @@ use instant::Instant;
 use std::marker::PhantomData;
 // use std::time::Instant;
 
+#[cfg(feature = "cli")]
 pub mod book;
 #[cfg(feature = "cli")]
 pub mod proof;
@@ -1050,6 +1051,17 @@ fn naive_minimax<T: TakBoard, E: Evaluator<Game = T>>(board: &mut T, eval: &E, d
         child_evaluations.max().unwrap()
     }
 }
+
+#[cfg(not(feature = "cli"))]
+mod book {
+    pub struct Book();
+    impl Book {
+        pub fn get<T>(&self, _: &T) -> Option<i32> {
+            return None;
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/search.rs
+++ b/src/search.rs
@@ -662,8 +662,7 @@ where
     if moves.len() == 0 {
         // if we don't have an immediate win, check TT move first
         if let Some(entry) = pv_entry {
-            if (entry.game_move.is_place_move() && board.legal_move(entry.game_move))
-                || stack_moves.contains(&entry.game_move)
+            if board.legal_move(entry.game_move)
             // TODO maybe a really fast legal checker is faster
             {
                 let m = entry.game_move;
@@ -726,7 +725,8 @@ where
             }
         }
     }
-
+    stack_moves.clear();
+    generate_all_stack_moves(board, &mut stack_moves);
     gen_and_score(depth, board, &mut stack_moves, &mut moves);
 
     if let Some(entry) = pv_entry {

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,8 +3,8 @@ use crate::board::TakBoard;
 use crate::eval::Evaluator;
 use crate::eval::{LOSE_SCORE, WIN_SCORE};
 use crate::move_gen::{
-    generate_aggressive_place_moves, generate_all_stack_moves, GameMove, HistoryMoves, KillerMoves,
-    MoveBuffer, RevGameMove, SmartMoveBuffer,
+    generate_aggressive_place_moves, generate_all_stack_moves, GameMove, KillerMoves, MoveBuffer,
+    PlaceHistory, RevGameMove, SmartMoveBuffer,
 };
 use crate::transposition_table::{HashEntry, HashTable, ScoreCutoff};
 use crate::{TeiCommand, TimeBank};
@@ -53,7 +53,7 @@ pub struct SearchInfo {
     pub nodes: usize,
     pv_table: HashTable,
     pub killer_moves: Vec<KillerMoves>,
-    pub hist_moves: HistoryMoves,
+    pub hist_moves: PlaceHistory<36>, // Todo make this better generic
     pub stack_win_kill: Vec<KillerMoves>,
     stopped: bool,
     input: Option<Receiver<TeiCommand>>,
@@ -73,7 +73,7 @@ impl SearchInfo {
             pv_table: HashTable::new(pv_size),
             killer_moves: vec![KillerMoves::new(); max_depth + 1],
             stack_win_kill: vec![KillerMoves::new(); max_depth + 1],
-            hist_moves: HistoryMoves::new(6), // Todo init in search
+            hist_moves: PlaceHistory::new(), // Todo init in search
             nodes: 0,
             stopped: false,
             input: None,
@@ -174,16 +174,7 @@ impl SearchInfo {
         forward
     }
     fn ply_depth<E: TakBoard>(&self, position: &E) -> usize {
-        if position.ply() < self.start_ply {
-            dbg!(self.start_ply);
-            dbg!(position.ply());
-            dbg!(&position);
-            let board = crate::Board5::try_from_tps(
-                "2,x,x,x,x/x,x,x,x,x/x,x,x,x,x/x,x,x,x,x/x,x,x,x,x 1 1",
-            )
-            .unwrap();
-            dbg!(board.ply());
-        }
+        assert!(position.ply() >= self.start_ply);
         position.ply() - self.start_ply
     }
     pub fn clear_tt(&mut self) {
@@ -695,14 +686,11 @@ where
                         info.stats.fail_high_first += 1;
                         info.stats.fail_high += 1;
                         info.stats.add_cut(0);
-                        if m.is_place_move() {
-                            info.killer_moves[board.ply() % info.max_depth].add(m);
+                        if m.is_stack_move() {
+                            let ply_depth = info.ply_depth(board);
+                            info.killer_moves[ply_depth].add(m);
                         } else {
-                            // const WINNING: i32 = crate::eval::WIN_SCORE - 100;
-                            // // Cannot be null?
-                            // if score >= WINNING {
-                            //     info.hist_moves.update(depth, m);
-                            // }
+                            info.hist_moves.update(depth, m);
                         }
                         info.store_move(
                             board,
@@ -727,7 +715,7 @@ where
     }
     stack_moves.clear();
     generate_all_stack_moves(board, &mut stack_moves);
-    gen_and_score(depth, board, &mut stack_moves, &mut moves);
+    gen_and_score(depth, board, &mut stack_moves, &mut moves, &info);
 
     if let Some(entry) = pv_entry {
         if has_searched_pv {
@@ -736,11 +724,10 @@ where
             moves.score_pv_move(entry.game_move);
         }
     }
-
+    let ply_depth = info.ply_depth(board);
     for c in 0..moves.len() {
         let count = if has_searched_pv { c + 1 } else { c };
-
-        let m = moves.get_best(board.ply(), info);
+        let m = moves.get_best(ply_depth, info);
 
         let rev_move = board.do_move(m);
         let next_extensions = extensions;
@@ -885,14 +872,11 @@ where
                 }
                 info.stats.fail_high += 1;
                 info.stats.add_cut(count);
-                if m.is_place_move() {
-                    info.killer_moves[board.ply() % info.max_depth].add(m);
+                if m.is_stack_move() {
+                    let ply_depth = info.ply_depth(board);
+                    info.killer_moves[ply_depth].add(m);
                 } else {
-                    const WINNING: i32 = crate::eval::WIN_SCORE - 100;
-                    // // Cannot be null?
-                    if score >= WINNING && count >= 8 {
-                        info.stack_win_kill[board.ply() % info.max_depth].add(m);
-                    }
+                    info.hist_moves.update(depth, m);
                 }
                 info.store_move(
                     board,
@@ -945,6 +929,7 @@ fn gen_and_score<T>(
     board: &mut T,
     stack_moves: &mut Vec<GameMove>,
     moves: &mut SmartMoveBuffer,
+    info: &SearchInfo,
 ) where
     T: TakBoard,
 {
@@ -960,7 +945,7 @@ fn gen_and_score<T>(
         let mut check_moves = Vec::new();
         generate_aggressive_place_moves(board, &mut check_moves);
         let tak_threats = board.get_tak_threats(&mut check_moves, None);
-        moves.gen_score_place_moves(board);
+        moves.gen_score_place_moves(board, &info.hist_moves);
         moves.score_tak_threats(&tak_threats);
         if board.ply() >= 4 {
             moves.score_stack_moves(board);
@@ -970,7 +955,7 @@ fn gen_and_score<T>(
             generate_all_stack_moves(board, moves);
             moves.score_stack_moves(board);
         }
-        moves.gen_score_place_moves(board);
+        moves.gen_score_place_moves(board, &info.hist_moves);
     }
     // moves.gen_score_place_moves(board);
     // if !must_capture {
@@ -994,6 +979,7 @@ fn gen_and_score<T>(
 // }
 
 /// A naive minimax function without pruning used for debugging and benchmarking
+#[cfg(test)]
 pub fn root_minimax<T, E>(board: &mut T, eval: &E, depth: u16) -> (Option<GameMove>, i32)
 where
     T: TakBoard,
@@ -1017,7 +1003,7 @@ where
     }
     (best_move, best_eval)
 }
-
+#[cfg(test)]
 fn naive_minimax<T: TakBoard, E: Evaluator<Game = T>>(board: &mut T, eval: &E, depth: u16) -> i32 {
     match board.game_result() {
         Some(GameResult::WhiteWin) => {

--- a/src/search/book.rs
+++ b/src/search/book.rs
@@ -1,6 +1,5 @@
-use crate::{Color, GameMove, TakBoard};
+use crate::{Color, GameMove, GameResult, TakBoard};
 use anyhow::Result;
-use board_game_traits::GameResult;
 use miniserde::{json, Deserialize, Serialize};
 use std::{collections::HashMap, io::Write};
 

--- a/src/search/proof.rs
+++ b/src/search/proof.rs
@@ -564,6 +564,10 @@ where
         }
         // Moves contains all stack moves due to the can_make_road call
         crate::move_gen::generate_aggressive_place_moves(pos, &mut moves);
+        // Give up
+        if depth + 2 >= 98 {
+            return AttackerOutcome::NoTakThreats;
+        }
         let tak_threats = pos.get_tak_threats(&moves, Some(self.top_moves[depth + 2].get_best()));
         if tak_threats.is_empty() {
             AttackerOutcome::NoTakThreats

--- a/src/search/proof.rs
+++ b/src/search/proof.rs
@@ -481,6 +481,8 @@ where
         // Todo optimization: only check if there is only one flat threat
         let placement =
             crate::board::find_placement_road(enemy, enemy_road_pieces, board.bits().empty());
+        moves.clear();
+        generate_all_stack_moves(board, &mut moves);
         assert!(moves.len() > 0); // All stack moves should already be generated
         generate_all_place_moves(board, &mut moves);
         // generate_all_moves(&board, &mut moves); // In practice generating them twice helps??
@@ -562,12 +564,13 @@ where
             self.top_moves[depth].add_move(m);
             return AttackerOutcome::HasRoad(m);
         }
-        // Moves contains all stack moves due to the can_make_road call
-        crate::move_gen::generate_aggressive_place_moves(pos, &mut moves);
         // Give up
         if depth + 2 >= 98 {
             return AttackerOutcome::NoTakThreats;
         }
+        moves.clear();
+        crate::move_gen::generate_all_stack_moves(pos, &mut moves);
+        crate::move_gen::generate_aggressive_place_moves(pos, &mut moves);
         let tak_threats = pos.get_tak_threats(&moves, Some(self.top_moves[depth + 2].get_best()));
         if tak_threats.is_empty() {
             AttackerOutcome::NoTakThreats

--- a/src/search/proof.rs
+++ b/src/search/proof.rs
@@ -561,7 +561,9 @@ where
         let pos = &mut self.board;
         let mut moves = Vec::new();
         if let Some(m) = pos.can_make_road(&mut moves, Some(self.top_moves[depth].get_best())) {
-            self.top_moves[depth].add_move(m);
+            if m.is_stack_move() {
+                self.top_moves[depth].add_move(m);
+            }
             return AttackerOutcome::HasRoad(m);
         }
         // Give up
@@ -575,9 +577,6 @@ where
         if tak_threats.is_empty() {
             AttackerOutcome::NoTakThreats
         } else {
-            for t in tak_threats.iter() {
-                self.top_moves[depth + 2].add_move(*t);
-            }
             AttackerOutcome::TakThreats(tak_threats)
         }
     }

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -149,7 +149,7 @@ pub fn main() {
             // println!("Computer Choose: {}", pv_move.to_ptn::<Board6>());
             // info.print_cuts();
             // let node_counts = search_efficiency(&["empty6"], 8);
-            let examine = vec![("temp", 16)];
+            let examine = vec![("midgame2", 10)];
             // let mut board = Board6::try_from_tps(saved_tps("start4").unwrap()).unwrap();
             // let mut eval = Weights6::default();
             // eval.add_noise();

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -4,6 +4,7 @@ use crate::Position;
 use anyhow::Result;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use getopts::Options;
+use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::env;
 use std::io::{self, BufRead};
@@ -16,6 +17,38 @@ use topaz_tak::eval::{Evaluator, Weights5, Weights6};
 use topaz_tak::search::book;
 use topaz_tak::search::{proof::TinueSearch, search, SearchInfo};
 use topaz_tak::*;
+
+lazy_static! {
+    static ref SAVED_TPS: HashMap<&'static str, &'static str> = {
+        let x = [
+        ("alion1", "2,1221122,1,1,1,2S/1,1,1,x,1C,1111212/x2,2,212,2C,11/2,2,x2,1,1/x3,1,1,x/x2,2,21,x,112S 2 32"),
+        ("alion2", "2,212221C,2,2,2C,1/1,2,1,1,2,1/12,x,1S,2S,2,1/2,2,2,x2,1/1,2212121S,2,12,1,1S/x,2,2,2,x,1 1 30"),
+        ("alion3", "x2,1,21,2,2/1,2,21,1,21,2/1S,2,2,2C,2,2/21S,1,121C,x,1,12/2,2,121,1,1,1/2,2,x3,22S 1 27"),
+        ("alion4", "x,1,x4/2,2,1,1,1,1/2221,x,1,21C,x2/2,2,2C,1,2,x/2,2,1,1,1,2/2,x2,2,x,1 2 18"),
+        ("alion5", "2,x4,11/x5,221/x,2,2,2,x,221/2,1,12C,1,21C,2/2,x,2,x2,2/x,2,2,2,x,121 1 25"),
+        ("empty6", "x6/x6/x6/x6/x6/x6 1 1"),
+        ("test5", "2,2,x2,1/2,2,x,1,1/1221S,1,122221C,x,1/1,12,x,2C,2/1S,2,2,x2 1 20"),
+        ("test7", concat!("2,2,21S,2,1,1,1/2,1,x,2,1,x,1/2,2,2,2,21112C,121S,x/x2,1112C,2,1,1112S,x/121,22211C,",
+            "1S,1,1,121,1221C/x,2,2,2,1,12,2/2,x3,1,122,x 2 50")),
+        ("topaz1", "x2,1,x,1212,x/x,221,2212221211C,2S,x2/x,221,1,2,2,x/221,2,12C,1,2,2/22221S,221S,1,1,2,x/12,x,12,1,1,x 1 44"),
+        ("opening1", "x2,2,x3/x,2,2,x3/x,1,1,2,2,1/1C,2,12C,1,1,x/x,2,x2,1,1/2,x4,1 1 11"), // Avoid falling way behind?
+        ("opening2", "2,x5/x3,1,2,x/2,2,221C,12C,1,2/x,2,x,1,1,x/x2,2,1,1,x/x2,2,x,1,1 1 13"), // Don't give black initiative for free
+        ("midgame1", "2,2,2222221C,x3/2,2,2S,12121S,x,2/2,2,1,1,1,1/x,1S,111112C,1,1,x/1,12112S,x4/x,2,x3,1 1 31"), // Tinue avoidance
+        ("midgame2", "x4,1,1/1,12S,2,2,1,1/1,1221S,1,21C,1,x/1,21112C,2,1,22221S,2/2,2,2,2S,1,2/x2,21,21,x,2 1 32"),
+        ("midgame3", "2,1,1,1,x2/x,2,2,1,x2/x,1,2,1C,1,1/x2,2,1112C,12S,2/x,2,2,1,x,1/2,2,x2,1,1 1 17"),
+        ("temp", "x6/x6/x3,2,2,1/x3,2,1,1/x,2,x2,1,1/2,x4,1 2 6"),
+        ("start", "x6/x2,2,2,x2/x6/x6/x6/1,x3,1,x 1 3"),
+        ("start2", "2,x5/x6/x6/x6/x2,1,x3/1,x5 2 2"),
+        ("start3", "x6/x4,2,1/x2,2,2C,1,2/x2,2,x,1,1/x5,1/x6 1 6"),
+        ("start4", "2,x4,1/x4,1,1/x2,2,21C,12C,x/1,1,1,2,1,1/x2,2,2,2,2/x6 2 11"),
+        ("tt1", "1,x4,2/1,12,1,1,1,2/2,12C,21C,2,21,1/1,1,2,2,2,1/1,x3,2,2/x6 2 16"),
+        ("endgame1", "1,2,1,1,1S,212212/112,22,x,1,1S,2/1,2,212C,2,1112S,x/x,2,1,1,12221C,2/1,1S,1S,12,x,22121S/1,12,1,2,x,2 1 46"),
+        ("endgame2", "2,x,2,2,1,1/1,2,2,1,12,1/1,2112S,x,1,2,1/21,2,2221S,2,2112C,2/2,121,1,2S,11221C,1/12,222221S,12,1,1,1 1 43"),
+        ("endgame3", "x2,21,122,1121S,112S/1S,x,1112,x,2S,x/112C,2S,x,1222221C,2,x/2,x2,1,2121S,x/112,1112111112S,x3,221S/2,2,x2,21,2 1 56"),
+        ].iter().map(|x| *x).collect();
+        x
+    };
+}
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();
@@ -42,6 +75,20 @@ pub fn main() {
             return;
         } else if arg1 == "magic" {
             gen_magics();
+            return;
+        } else if arg1 == "order" {
+            let vals: Vec<_> = SAVED_TPS
+                .values()
+                .filter_map(|tps| {
+                    if Board6::try_from_tps(tps).is_ok() {
+                        Some((*tps, 12))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            let nodes = search_efficiency(&vals, true).unwrap();
+            dbg!(nodes.into_iter().sum::<usize>());
             return;
         } else if arg1 == "book" {
             let book = Arc::new(Mutex::new(book::Book::new(
@@ -151,7 +198,7 @@ pub fn main() {
             // println!("Computer Choose: {}", pv_move.to_ptn::<Board6>());
             // info.print_cuts();
             // let node_counts = search_efficiency(&["empty6"], 8);
-            let examine = vec![("midgame2", 10)];
+            let examine = vec![("opening1", 12)];
             // let mut board = Board6::try_from_tps(saved_tps("start4").unwrap()).unwrap();
             // let mut eval = Weights6::default();
             // eval.add_noise();
@@ -267,34 +314,7 @@ fn build_tps(args: &[String]) -> Result<TakGame> {
 }
 
 fn saved_tps(name: &str) -> Option<&str> {
-    let s = match name {
-        "alion1" => "2,1221122,1,1,1,2S/1,1,1,x,1C,1111212/x2,2,212,2C,11/2,2,x2,1,1/x3,1,1,x/x2,2,21,x,112S 2 32",
-        "alion2" => "2,212221C,2,2,2C,1/1,2,1,1,2,1/12,x,1S,2S,2,1/2,2,2,x2,1/1,2212121S,2,12,1,1S/x,2,2,2,x,1 1 30",
-        "alion3" => "x2,1,21,2,2/1,2,21,1,21,2/1S,2,2,2C,2,2/21S,1,121C,x,1,12/2,2,121,1,1,1/2,2,x3,22S 1 27",
-        "alion4" => "x,1,x4/2,2,1,1,1,1/2221,x,1,21C,x2/2,2,2C,1,2,x/2,2,1,1,1,2/2,x2,2,x,1 2 18",
-        "alion5" => "2,x4,11/x5,221/x,2,2,2,x,221/2,1,12C,1,21C,2/2,x,2,x2,2/x,2,2,2,x,121 1 25",
-        "empty6" => "x6/x6/x6/x6/x6/x6 1 1",
-        "test5" => "2,2,x2,1/2,2,x,1,1/1221S,1,122221C,x,1/1,12,x,2C,2/1S,2,2,x2 1 20",
-        "test7" => concat!("2,2,21S,2,1,1,1/2,1,x,2,1,x,1/2,2,2,2,21112C,121S,x/x2,1112C,2,1,1112S,x/121,22211C,",
-            "1S,1,1,121,1221C/x,2,2,2,1,12,2/2,x3,1,122,x 2 50"),
-        "topaz1" => "x2,1,x,1212,x/x,221,2212221211C,2S,x2/x,221,1,2,2,x/221,2,12C,1,2,2/22221S,221S,1,1,2,x/12,x,12,1,1,x 1 44",
-        "opening1" => "x2,2,x3/x,2,2,x3/x,1,1,2,2,1/1C,2,12C,1,1,x/x,2,x2,1,1/2,x4,1 1 11", // Avoid falling way behind?
-        "opening2" => "2,x5/x3,1,2,x/2,2,221C,12C,1,2/x,2,x,1,1,x/x2,2,1,1,x/x2,2,x,1,1 1 13", // Don't give black initiative for free
-        "midgame1" => "2,2,2222221C,x3/2,2,2S,12121S,x,2/2,2,1,1,1,1/x,1S,111112C,1,1,x/1,12112S,x4/x,2,x3,1 1 31", // Tinue avoidance
-        "midgame2" => "x4,1,1/1,12S,2,2,1,1/1,1221S,1,21C,1,x/1,21112C,2,1,22221S,2/2,2,2,2S,1,2/x2,21,21,x,2 1 32",
-        "midgame3" => "2,1,1,1,x2/x,2,2,1,x2/x,1,2,1C,1,1/x2,2,1112C,12S,2/x,2,2,1,x,1/2,2,x2,1,1 1 17",
-        "temp" => "x6/x6/x3,2,2,1/x3,2,1,1/x,2,x2,1,1/2,x4,1 2 6",
-        "start" => "x6/x2,2,2,x2/x6/x6/x6/1,x3,1,x 1 3",
-        "start2" => "2,x5/x6/x6/x6/x2,1,x3/1,x5 2 2",
-        "start3" => "x6/x4,2,1/x2,2,2C,1,2/x2,2,x,1,1/x5,1/x6 1 6",
-        "start4" => "2,x4,1/x4,1,1/x2,2,21C,12C,x/1,1,1,2,1,1/x2,2,2,2,2/x6 2 11",
-        "tt1" => "1,x4,2/1,12,1,1,1,2/2,12C,21C,2,21,1/1,1,2,2,2,1/1,x3,2,2/x6 2 16",
-        "endgame1" => "1,2,1,1,1S,212212/112,22,x,1,1S,2/1,2,212C,2,1112S,x/x,2,1,1,12221C,2/1,1S,1S,12,x,22121S/1,12,1,2,x,2 1 46",
-        "endgame2" => "2,x,2,2,1,1/1,2,2,1,12,1/1,2112S,x,1,2,1/21,2,2221S,2,2112C,2/2,121,1,2S,11221C,1/12,222221S,12,1,1,1 1 43",
-        "endgame3" => "x2,21,122,1121S,112S/1S,x,1112,x,2S,x/112C,2S,x,1222221C,2,x/2,x2,1,2121S,x/112,1112111112S,x3,221S/2,2,x2,21,2 1 56",
-        _ => {return None}
-    };
-    Some(s)
+    SAVED_TPS.get(name).map(|x| *x)
 }
 
 fn search_efficiency(names: &[(&str, usize)], save: bool) -> Result<Vec<usize>> {
@@ -319,7 +339,11 @@ fn search_efficiency(names: &[(&str, usize)], save: bool) -> Result<Vec<usize>> 
         }
     };
     for (name, depth) in names {
-        let tps = saved_tps(name).unwrap();
+        let tps = if let Some(tps) = saved_tps(name) {
+            tps
+        } else {
+            name
+        };
         let mut board = Board6::try_from_tps(tps).unwrap();
         let eval = Weights6::default();
         let mut info = SearchInfo::new(*depth, 2 << 20);
@@ -639,7 +663,7 @@ impl GameInitializer {
 
 fn play_game_playtak(server_send: Sender<String>, server_recv: Receiver<TeiCommand>) -> Result<()> {
     const MAX_DEPTH: usize = 32;
-    const KOMI: u8 = 4;
+    const KOMI: u8 = 0;
     let mut move_cache = Vec::new();
     let mut last_score = 0;
     let mut my_side = None;
@@ -716,7 +740,7 @@ fn play_game_playtak(server_send: Sender<String>, server_recv: Receiver<TeiComma
 }
 
 fn playtak_loop(engine_send: Sender<TeiCommand>, engine_recv: Receiver<String>) {
-    static OPP: &'static str = "Guest1243"; // Todo make this env variable
+    let mut opp = "Tiltak_Bot"; // Todo make this env variable
     let login_s = if let Some((user, pass)) = playtak_auth() {
         format!("Login {} {}\n", user, pass)
     } else {
@@ -764,7 +788,7 @@ fn playtak_loop(engine_send: Sender<TeiCommand>, engine_recv: Receiver<String>) 
                                     dbg!(line);
                                 }
                             } else if line.starts_with("Seek new") {
-                                if line.contains(OPP) {
+                                if line.contains(opp) {
                                     goal =
                                         Some(line.split_whitespace().nth(2).unwrap().to_string());
                                     println!("Goal: {:?}", goal);
@@ -776,6 +800,7 @@ fn playtak_loop(engine_send: Sender<TeiCommand>, engine_recv: Receiver<String>) 
                                 playing = true;
                                 dbg!(&game_id);
                                 dbg!(&my_color);
+                                opp = "NONE";
                             }
                         }
                     }

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -899,6 +899,7 @@ fn save_playtak_book(book: &book::Book) -> Result<()> {
     let pt_book = pt_book.ok_or_else(|| anyhow!("Could not find book path to write to"))?;
     let mut file = std::fs::OpenOptions::new()
         .write(true)
+        .create(true)
         .truncate(true)
         .open(&pt_book)?;
     let write_string = json::to_string(book);

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::style)]
 
-use crate::eval::Evaluator6;
 use crate::Position;
 use anyhow::Result;
 use crossbeam_channel::{unbounded, Receiver, Sender};
@@ -415,7 +414,7 @@ fn proof_interactive<T: TakBoard>(mut search: TinueSearch<T>) -> Result<()> {
 
 fn play_game_cmd(mut computer_turn: bool) {
     let mut board = Board6::new();
-    let eval = Evaluator6 {};
+    let eval = Weights6::default();
     while let None = board.game_result() {
         println!("{:?}", &board);
         if computer_turn {
@@ -714,7 +713,7 @@ fn play_game_playtak(server_send: Sender<String>, server_recv: Receiver<TeiComma
 }
 
 fn playtak_loop(engine_send: Sender<TeiCommand>, engine_recv: Receiver<String>) {
-    static OPP: &'static str = "Dummy"; // Todo make this env variable
+    static OPP: &'static str = "Guest1243"; // Todo make this env variable
     let login_s = if let Some((user, pass)) = playtak_auth() {
         format!("Login {} {}\n", user, pass)
     } else {

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -42,6 +42,7 @@ pub fn main() {
             return;
         } else if arg1 == "magic" {
             gen_magics();
+            return;
         } else if arg1 == "book" {
             let book = Arc::new(Mutex::new(book::Book::new(
                 search::book::BookMode::Learn,
@@ -914,5 +915,5 @@ fn gen_magics() {
     let mut seed: [u8; 32] = [0; 32];
     getrandom::getrandom(&mut seed).unwrap();
     let mut rng = rand_xoshiro::Xoshiro256PlusPlus::from_seed(seed);
-    topaz_tak::generate_move_magic6(&mut rng);
+    topaz_tak::move_gen::magic::generate_move_magic6(&mut rng);
 }

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -40,6 +40,8 @@ pub fn main() {
                 _ => todo!(),
             }
             return;
+        } else if arg1 == "magic" {
+            gen_magics();
         } else if arg1 == "book" {
             let book = Arc::new(Mutex::new(book::Book::new(
                 search::book::BookMode::Learn,
@@ -905,4 +907,12 @@ fn save_playtak_book(book: &book::Book) -> Result<()> {
     write!(&mut file, "{}", write_string)?;
     file.flush()?;
     Ok(())
+}
+
+fn gen_magics() {
+    use rand_core::SeedableRng;
+    let mut seed: [u8; 32] = [0; 32];
+    getrandom::getrandom(&mut seed).unwrap();
+    let mut rng = rand_xoshiro::Xoshiro256PlusPlus::from_seed(seed);
+    topaz_tak::generate_move_magic6(&mut rng);
 }

--- a/src/topaz.rs
+++ b/src/topaz.rs
@@ -296,7 +296,6 @@ fn saved_tps(name: &str) -> Option<&str> {
 }
 
 fn search_efficiency(names: &[(&str, usize)], save: bool) -> Result<Vec<usize>> {
-    use std::collections::HashMap;
     use std::io::Write;
     let mut vec = Vec::new();
     let old = {
@@ -480,14 +479,6 @@ impl TimeLeft {
             Color::Black => (self.btime, self.binc),
         };
         (time_bank, inc)
-    }
-    fn use_time(&self, est_plies: usize, side_to_move: Color) -> u64 {
-        let (time_bank, inc) = match side_to_move {
-            Color::White => (self.wtime, self.winc),
-            Color::Black => (self.btime, self.binc),
-        };
-        let use_bank = time_bank / (est_plies + 2) as u64 / 1000;
-        use_bank + inc / 1000
     }
 }
 


### PR DESCRIPTION
Use fixed size stack representation instead of a vector. With 64 bits this is lossless for size 5 and 6 boards, but there is a chance for information loss with 7s or 8s. Nonetheless, the speedups should be worth it, and reaching stacks of size 64 should not be reasonable for any real game. 