### PR TITLE
Fix PV: reset child table_length, record forced road move, emit info on pv change

### DIFF
--- a/src/move_gen/move_order.rs
+++ b/src/move_gen/move_order.rs
@@ -168,7 +168,6 @@ impl SmartMoveBuffer {
                 dest = board.index(step.index);
                 let covered = dest.top();
                 let covering = stack_data[offset];
-                let bit_idx = 1 << step.index;
                 if let Some(piece) = covered {
                     if piece.owner() == active_side {
                         if piece.is_flat() {

--- a/src/search.rs
+++ b/src/search.rs
@@ -172,6 +172,32 @@ where
                 }
                 break 'outer;
             }
+            if pv_moves.is_empty() {
+                // The root search returned no PV (e.g. all candidate root
+                // moves were forbidden in multipv, or a fail-low produced
+                // no improving move). Treat this as the end of useful work.
+                if pv_idx == 0 {
+                    if let Some(data) = outcome {
+                        let updated = SearchOutcome::new(data.score, data.pv, data.depth, info);
+                        outcome = Some(updated);
+                    }
+                    break 'outer;
+                }
+                if !info.quiet && is_multi_pv {
+                    for (idx, res) in outcomes.iter_mut().enumerate() {
+                        res.update_multipv_index(idx + 1);
+                    }
+                    if let Some((last_pv, result)) = outcomes.split_last_mut() {
+                        for res in result {
+                            res.update_multipv(last_pv);
+                        }
+                    }
+                    for line in outcomes.drain(..) {
+                        println!("{}", line);
+                    }
+                }
+                break;
+            }
             if pv_idx == 0 {
                 outcome = Some(SearchOutcome::new(
                     best_score,

--- a/src/search.rs
+++ b/src/search.rs
@@ -280,6 +280,10 @@ where
     if (info.nodes() & FREQ) == FREQ {
         info.check_stop();
     }
+    let ply_depth = info.ply_depth(board);
+    if ply_depth < info.pv_table.table_length.len() {
+        info.pv_table.table_length[ply_depth] = 0;
+    }
     match board.game_result() {
         Some(GameResult::WhiteWin) => {
             if let Color::White = board.side_to_move() {
@@ -300,7 +304,6 @@ where
         return DRAW_SCORE;
     }
 
-    let ply_depth = info.ply_depth(board);
     // let mut road_move = None;
     if depth == 0 {
         let side = board.side_to_move();
@@ -316,11 +319,12 @@ where
             }
         }
 
-        if board
-            .can_make_road(&mut info.extra_move_buffer, None)
-            .is_some()
-        {
+        if let Some(road_move) = board.can_make_road(&mut info.extra_move_buffer, None) {
             info.extra_move_buffer.clear();
+            if ply_depth < info.pv_table.table_length.len() {
+                info.pv_table.table[ply_depth][ply_depth] = road_move;
+                info.pv_table.table_length[ply_depth] = 1;
+            }
             return WIN_SCORE - board.ply() as i32 + info.start_ply as i32 - 1;
         }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -11,7 +11,7 @@ use crate::{Bitboard, TeiCommand};
 #[cfg(feature = "cli")]
 pub mod book;
 mod util;
-pub use util::{HashHistory, SearchHyper, SearchInfo, SearchOutcome, SearchStats};
+pub use util::{HashHistory, ScoreBound, SearchHyper, SearchInfo, SearchOutcome, SearchStats};
 
 const DRAW_SCORE: i32 = 0;
 
@@ -37,6 +37,7 @@ const FUTILITY_MARGIN: i32 = 50;
 // CAN CAUSE CUT-OFF ON ROOT WHEN USED WITH PV_SEARCH!!!
 const ASPIRATION_ENABLED: bool = true; // Requires stable search, it's close
 const ASPIRATION_WINDOW: i32 = 55;
+const ASPIRATION_REPORT_DELAY_MS: u128 = 1000;
 
 // internal iterative deepening parameters TODO not tuned yet
 // doesn't have much cost attached to it, so why not
@@ -123,14 +124,17 @@ where
             );
             if ASPIRATION_ENABLED {
                 if (best_score <= alpha) || (best_score >= beta) {
+                    report_aspiration_bound::<T>(info, best_score, alpha, beta, depth, num_pvs);
                     let diff = beta - alpha;
+                    let wide_alpha = alpha - 2 * diff;
+                    let wide_beta = beta + 2 * diff;
                     best_score = alpha_beta(
                         board,
                         eval,
                         info,
                         SearchData::new(
-                            alpha - 2 * diff,
-                            beta + 2 * diff,
+                            wide_alpha,
+                            wide_beta,
                             depth,
                             true,
                             None,
@@ -142,6 +146,9 @@ where
                         &mut moves,
                     );
                     if (best_score <= alpha) || (best_score >= beta) {
+                        report_aspiration_bound::<T>(
+                            info, best_score, wide_alpha, wide_beta, depth, num_pvs,
+                        );
                         best_score = alpha_beta(
                             board,
                             eval,
@@ -212,6 +219,34 @@ where
     info.hist_moves.clear();
     info.counter_moves.clear();
     outcome
+}
+
+fn report_aspiration_bound<T>(
+    info: &SearchInfo,
+    score: i32,
+    search_alpha: i32,
+    search_beta: i32,
+    depth: usize,
+    num_pvs: usize,
+) where
+    T: TakBoard,
+{
+    if info.quiet || !info.main_thread || num_pvs > 1 {
+        return;
+    }
+    if info.start_time.elapsed().as_millis() < ASPIRATION_REPORT_DELAY_MS {
+        return;
+    }
+    let (display_score, bound) = if score <= search_alpha {
+        (search_alpha, ScoreBound::Upper)
+    } else if score >= search_beta {
+        (search_beta, ScoreBound::Lower)
+    } else {
+        return;
+    };
+    let pv_moves = info.pv_table.get_pv();
+    let outcome = SearchOutcome::<T>::new(display_score, pv_moves, depth, info).with_bound(bound);
+    println!("{}", outcome);
 }
 
 #[derive(Clone)]

--- a/src/search.rs
+++ b/src/search.rs
@@ -89,7 +89,7 @@ where
     eval.set_tempo_offset(info.hyper.tempo_bonus);
     let mut alphas = [-1_000_000; 8];
     let mut betas = [1_000_000; 8];
-    let mut solved = [false; 8];
+    let mut scores = [0_i32; 8];
     // let mut alpha = -1_000_000;
     // let mut beta = 1_000_000;
     let mut moves: [SmartMoveBuffer; 50] = core::array::from_fn(|_| SmartMoveBuffer::new(0));
@@ -108,8 +108,13 @@ where
         }
         info.forbidden_root_moves.clear();
         let num_pvs = info.multi_pv as usize;
-        if solved[num_pvs - 1] {
-            // Stop wasting time
+        // Only stop when no reported PV can still gain accuracy: the worst line
+        // is a win in <= 2 plies (so all lines are, and no shorter win is
+        // hidden), or the best line is mated in 1 (so every line is). Greater
+        // mate distances can still shorten under extensions/reductions, and in
+        // multipv the lower lines may still be moving even once the top one is
+        // settled. The all-zero init can't trigger before the first depth.
+        if scores[num_pvs - 1] >= WIN_SCORE - 2 || scores[0] <= LOSE_SCORE + 1 {
             break;
         }
         for pv_idx in 0..num_pvs {
@@ -236,10 +241,8 @@ where
                     }
                 }
             }
-            // Stop wasting time
-            if best_score > WIN_SCORE - 10 || best_score < LOSE_SCORE + 10 {
-                solved[pv_idx] = true;
-            }
+            // Record for the early-out check at the top of the next iteration.
+            scores[pv_idx] = best_score;
         }
     }
     info.hist_moves.clear();

--- a/src/search/util.rs
+++ b/src/search/util.rs
@@ -330,6 +330,13 @@ impl SearchStats {
         }
     }
 }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScoreBound {
+    Exact,
+    Lower,
+    Upper,
+}
+
 #[derive(Debug, Clone)]
 pub struct SearchOutcome<T> {
     pub score: i32,
@@ -341,6 +348,7 @@ pub struct SearchOutcome<T> {
     pub hashfull: usize,
     pub phantom: PhantomData<T>,
     multi_pv_idx: usize,
+    bound: ScoreBound,
 }
 
 impl<T> SearchOutcome<T>
@@ -362,7 +370,12 @@ where
             hashfull: search_info.trans_table.occupancy(),
             phantom: PhantomData,
             multi_pv_idx: 0,
+            bound: ScoreBound::Exact,
         }
+    }
+    pub fn with_bound(mut self, bound: ScoreBound) -> Self {
+        self.bound = bound;
+        self
     }
     pub fn update_multipv_index(&mut self, idx: usize) {
         self.multi_pv_idx = idx;
@@ -403,13 +416,19 @@ where
         } else {
             0
         };
+        let bound_str = match self.bound {
+            ScoreBound::Exact => "",
+            ScoreBound::Lower => " lowerbound",
+            ScoreBound::Upper => " upperbound",
+        };
         if self.multi_pv_idx > 0 {
             write!(
                 f,
-                "info depth {} multipv {} score cp {} time {} nodes {} nps {} hashfull {} pv {}",
+                "info depth {} multipv {} score cp {}{} time {} nodes {} nps {} hashfull {} pv {}",
                 self.depth,
                 self.multi_pv_idx,
                 readable_eval(self.score),
+                bound_str,
                 self.time,
                 self.nodes,
                 nps,
@@ -419,9 +438,10 @@ where
         } else {
             write!(
                 f,
-                "info depth {} score cp {} time {} nodes {} nps {} hashfull {} pv {}",
+                "info depth {} score cp {}{} time {} nodes {} nps {} hashfull {} pv {}",
                 self.depth,
                 readable_eval(self.score),
+                bound_str,
                 self.time,
                 self.nodes,
                 nps,


### PR DESCRIPTION
PVTable::update copied table_length[ply+1] entries from the child without
the child ever zeroing its own length, so when alpha_beta returned early
via game_result the parent appended stale moves from a prior sibling
search past the game-ending move. Reset table_length[ply_depth] at the
top of every alpha_beta call.

The depth-0 can_make_road branch returned WIN_SCORE without recording
the winning move, so a forced road dropped off the end of the PV.
Capture the returned move and write it into the PV table before
returning.

Also adds a ScoreBound enum and a with_bound setter on SearchOutcome; the
end-of-depth path keeps Exact, so the existing output is unchanged
except for the new intermediate lines.